### PR TITLE
Add symbolized disassembly support

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -687,11 +687,11 @@ class TestListBreakpoints:
 class TestDisassemble:
     def test_disassemble(self, mock_client):
         ins1 = Instruction(
-            instruction="nop", argcount=0, instr_size=1,
+            instruction="nop", symbolized_instruction="nop", argcount=0, instr_size=1,
             type=DisasmInstrType.Normal, arg=[],
         )
         ins2 = Instruction(
-            instruction="ret", argcount=0, instr_size=1,
+            instruction="ret", symbolized_instruction="ret", argcount=0, instr_size=1,
             type=DisasmInstrType.Normal, arg=[],
         )
         mock_client.disassemble_at.side_effect = [ins1, ins2]

--- a/x64dbg_automate/commands_xauto.py
+++ b/x64dbg_automate/commands_xauto.py
@@ -335,9 +335,10 @@ class XAutoCommandsMixin(XAutoClientBase):
             return None
         return Instruction(
             instruction=res[0],
-            argcount=res[1],
-            instr_size=res[2],
-            type=DisasmInstrType(res[3]),
+            symbolized_instruction=res[1],
+            argcount=res[2],
+            instr_size=res[3],
+            type=DisasmInstrType(res[4]),
             arg=[InstructionArg(
                     mnemonic=arg[0],
                     type=DisasmArgType(arg[1]),
@@ -345,7 +346,7 @@ class XAutoCommandsMixin(XAutoClientBase):
                     constant=arg[3],
                     value=arg[4],
                     memvalue=arg[5],
-            ) for arg in res[4]]
+            ) for arg in res[5]]
         )
     
     def _assemble_at(self, addr: int, instr: str) -> bool:

--- a/x64dbg_automate/mcp_server.py
+++ b/x64dbg_automate/mcp_server.py
@@ -835,7 +835,7 @@ def disassemble(address: str, count: int = 10) -> str:
             if ins is None:
                 lines.append(f"{_format_address(current)}  ???")
                 break
-            lines.append(f"{_format_address(current)}  {ins.instruction}")
+            lines.append(f"{_format_address(current)}  {ins.symbolized_instruction}")
             current += ins.instr_size
         return "\n".join(lines)
     except Exception as e:

--- a/x64dbg_automate/models.py
+++ b/x64dbg_automate/models.py
@@ -342,6 +342,7 @@ class InstructionArg(BaseModel):
 
 class Instruction(BaseModel):
     instruction: str
+    symbolized_instruction: str
     argcount: int
     instr_size: int
     type: DisasmInstrType


### PR DESCRIPTION
Add support for retrieving symbolized assembly instructions ( https://github.com/dariushoule/x64dbg-automate/pull/5 )

Consumers of disassemble_at currently receive the raw instruction text, which omit useful symbol information in x64dbg. Returning both raw and symbolized forms makes the API more useful for automation, MCP integrations, and human-readable analysis output.

Changes:

* Update disassemble_at response parsing for the new tuple layout
* Add symbolized_instruction to the Instruction model
* Update MCP disassemble output to display symbolized instructions