### PR TITLE
Add log capture support: EVENT_LOG_MESSAGE, get_log command, MCP tool

### DIFF
--- a/docs/api/debug-control.md
+++ b/docs/api/debug-control.md
@@ -298,6 +298,12 @@ client.detach_session()
         show_root_full_path: false
 
 
+::: x64dbg_automate.X64DbgClient.get_log
+    options:
+        show_root_heading: true
+        show_root_full_path: false
+
+
 ### API Model Reference
 
 ::: x64dbg_automate.events.DbgEvent
@@ -308,6 +314,13 @@ client.detach_session()
 
 
 ::: x64dbg_automate.events.EventType
+    options:
+        show_root_heading: true
+        show_root_full_path: false
+        show_bases: false
+
+
+::: x64dbg_automate.events.LogMessageEventData
     options:
         show_root_heading: true
         show_root_full_path: false

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -93,7 +93,7 @@ The MCP server provides ~40 tools organized into the following groups:
 | Threads | `create_thread`, `terminate_thread`, `pause_resume_thread`, `switch_thread` | Thread management |
 | Events | `get_latest_event`, `wait_for_event` | Debug event queue |
 | Settings | `get_setting`, `set_setting` | x64dbg configuration |
-| GUI | `log_message`, `refresh_gui` | Debugger UI interaction |
+| GUI | `log_message`, `get_log`, `refresh_gui` | Debugger UI interaction, log capture |
 
 ### Remote Debugging (VM / Network)
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,113 @@
+"""
+Pure unit tests for debug-event parsing. These do not require a live x64dbg
+instance and exercise the wire-shape -> typed-model mapping in events.py.
+"""
+from x64dbg_automate.events import (
+    DbgEvent,
+    DebugEventQueueMixin,
+    EventType,
+    LogMessageEventData,
+)
+
+
+def test_log_message_event_parsing():
+    # DbgEvent receives the event type and the trailing argument tuple, so the
+    # message published by the plugin as ("EVENT_LOG_MESSAGE", msg) arrives here
+    # as event_data[0].
+    event = DbgEvent(EventType.EVENT_LOG_MESSAGE, ["hello from x64dbg"])
+    assert event.event_type == EventType.EVENT_LOG_MESSAGE
+    assert isinstance(event.event_data, LogMessageEventData)
+    assert event.event_data.text == "hello from x64dbg"
+
+
+def test_log_message_event_dispatch_and_watch():
+    class Queue(DebugEventQueueMixin):
+        pass
+
+    q = Queue()
+    received: list[DbgEvent] = []
+
+    callback = lambda e: received.append(e)
+    q.watch_debug_event(EventType.EVENT_LOG_MESSAGE, callback)
+    try:
+        # debug_event_publish consumes the raw wire list: [type, *args]
+        event = q.debug_event_publish(["EVENT_LOG_MESSAGE", "buffered line"])
+        assert event.event_type == EventType.EVENT_LOG_MESSAGE
+        assert event.event_data.text == "buffered line"
+        assert len(received) == 1
+        assert received[0].event_data.text == "buffered line"
+    finally:
+        q.unwatch_debug_event(EventType.EVENT_LOG_MESSAGE, callback)
+
+
+def test_log_events_do_not_evict_other_events():
+    # A flood of EVENT_LOG_MESSAGE must not push a non-log event out of the main
+    # queue -- the whole point of the separate log queue.
+    q = DebugEventQueueMixin()
+    q._init_event_queues(log_event_queue_maxlen=5)
+
+    # one important non-log event
+    q.debug_event_publish(["EVENT_SYSTEMBREAKPOINT", 0])
+
+    # flood with far more log events than either cap
+    for i in range(50):
+        q.debug_event_publish(["EVENT_LOG_MESSAGE", f"line {i}"])
+
+    # the non-log event survived in its own (main) queue
+    ev = q.wait_for_debug_event(EventType.EVENT_SYSTEMBREAKPOINT, timeout=1)
+    assert ev is not None
+    assert ev.event_type == EventType.EVENT_SYSTEMBREAKPOINT
+
+    # the log queue is bounded to its cap and holds only the most recent lines
+    assert len(q._log_events_q) == 5
+    msgs = [e.event_data.text for e in q._log_events_q]
+    assert msgs == [f"line {i}" for i in range(45, 50)]
+
+
+def test_log_event_queue_maxlen_configurable_and_resizable():
+    q = DebugEventQueueMixin()
+    q._init_event_queues(log_event_queue_maxlen=3)
+    assert q.log_event_queue_maxlen == 3
+
+    for i in range(10):
+        q.debug_event_publish(["EVENT_LOG_MESSAGE", str(i)])
+    assert len(q._log_events_q) == 3
+    assert [e.event_data.text for e in q._log_events_q] == ["7", "8", "9"]
+
+    # shrinking the cap keeps the most recent events
+    q.log_event_queue_maxlen = 2
+    assert q.log_event_queue_maxlen == 2
+    assert [e.event_data.text for e in q._log_events_q] == ["8", "9"]
+
+
+def test_clear_debug_events_targets_correct_queue():
+    q = DebugEventQueueMixin()
+    q._init_event_queues()
+    q.debug_event_publish(["EVENT_SYSTEMBREAKPOINT", 0])
+    q.debug_event_publish(["EVENT_LOG_MESSAGE", "a"])
+
+    # clearing only log events leaves the main queue intact
+    q.clear_debug_events(EventType.EVENT_LOG_MESSAGE)
+    assert len(q._log_events_q) == 0
+    assert q.peek_latest_debug_event().event_type == EventType.EVENT_SYSTEMBREAKPOINT
+
+    # clearing everything empties both
+    q.debug_event_publish(["EVENT_LOG_MESSAGE", "b"])
+    q.clear_debug_events()
+    assert len(q._log_events_q) == 0
+    assert len(q._debug_events_q) == 0
+
+
+def test_get_latest_excludes_log_events():
+    q = DebugEventQueueMixin()
+    q._init_event_queues()
+    q.debug_event_publish(["EVENT_SYSTEMBREAKPOINT", 0])
+    q.debug_event_publish(["EVENT_LOG_MESSAGE", "noise"])
+
+    # get_latest / peek operate on the main queue only; log noise never masks
+    # the real event.
+    assert q.peek_latest_debug_event().event_type == EventType.EVENT_SYSTEMBREAKPOINT
+    assert q.get_latest_debug_event().event_type == EventType.EVENT_SYSTEMBREAKPOINT
+    assert q.get_latest_debug_event() is None  # main queue now empty
+    # the log event is still retrievable from its own queue
+    assert q.wait_for_debug_event(EventType.EVENT_LOG_MESSAGE, timeout=1).event_data.text == "noise"

--- a/x64dbg_automate/__init__.py
+++ b/x64dbg_automate/__init__.py
@@ -12,7 +12,7 @@ import psutil
 import shutil
 import zmq
 
-from x64dbg_automate.events import DebugEventQueueMixin
+from x64dbg_automate.events import DebugEventQueueMixin, DEFAULT_LOG_EVENT_QUEUE_MAXLEN
 from x64dbg_automate.hla_xauto import XAutoHighLevelCommandAbstractionMixin
 from x64dbg_automate.models import DebugSession
 
@@ -44,7 +44,8 @@ class ClientConnectionFailedError(Exception):
 
 class X64DbgClient(XAutoHighLevelCommandAbstractionMixin, DebugEventQueueMixin):
     def _init_fields(self, x64dbg_path: str | None = None, remote_host: str = "localhost",
-                     req_rep_port: int = 0, pub_sub_port: int = 0):
+                     req_rep_port: int = 0, pub_sub_port: int = 0,
+                     log_event_queue_maxlen: int = DEFAULT_LOG_EVENT_QUEUE_MAXLEN):
         self.x64dbg_path = x64dbg_path
         self.proc = None
         self.session_pid = None
@@ -55,18 +56,30 @@ class X64DbgClient(XAutoHighLevelCommandAbstractionMixin, DebugEventQueueMixin):
         self.sess_pub_sub_port = pub_sub_port
         self.remote_host = remote_host
         self._req_lock = threading.Lock()
+        self._init_event_queues(log_event_queue_maxlen)
         all_instances.append(self)
 
-    def __init__(self, x64dbg_path: str = "x64dbg"):
+    def __init__(self, x64dbg_path: str = "x64dbg",
+                 log_event_queue_maxlen: int = DEFAULT_LOG_EVENT_QUEUE_MAXLEN):
+        """
+        Args:
+            x64dbg_path: Path to the x64dbg executable (or a name resolvable on PATH).
+            log_event_queue_maxlen: Maximum number of `EVENT_LOG_MESSAGE` events
+                retained in the dedicated log-event queue. Log events are kept
+                separate from other debug events so a verbose log stream (e.g. a
+                trace) cannot evict breakpoint/step events. Can also be changed
+                later via the `log_event_queue_maxlen` property.
+        """
         resolved = x64dbg_path
         if not Path(resolved).is_file():
             resolved = shutil.which(x64dbg_path)
         if resolved is None or not Path(resolved).is_file():
             raise FileNotFoundError(f"x64dbg executable not found at {x64dbg_path} or in PATH")
-        self._init_fields(x64dbg_path=resolved)
+        self._init_fields(x64dbg_path=resolved, log_event_queue_maxlen=log_event_queue_maxlen)
 
     @classmethod
-    def connect_remote(cls, host: str, req_rep_port: int, pub_sub_port: int) -> 'X64DbgClient':
+    def connect_remote(cls, host: str, req_rep_port: int, pub_sub_port: int,
+                       log_event_queue_maxlen: int = DEFAULT_LOG_EVENT_QUEUE_MAXLEN) -> 'X64DbgClient':
         """Connect to a remote x64dbg instance by host and port pair.
 
         This bypasses local session discovery (lockfiles) and connects directly
@@ -76,12 +89,15 @@ class X64DbgClient(XAutoHighLevelCommandAbstractionMixin, DebugEventQueueMixin):
             host: Remote hostname or IP address (e.g. '192.168.1.100')
             req_rep_port: The REQ/REP port the plugin is listening on
             pub_sub_port: The PUB/SUB port the plugin is listening on
+            log_event_queue_maxlen: Maximum number of `EVENT_LOG_MESSAGE` events
+                retained in the dedicated log-event queue (see `__init__`).
 
         Returns:
             A connected X64DbgClient instance
         """
         client = cls.__new__(cls)
-        client._init_fields(remote_host=host, req_rep_port=req_rep_port, pub_sub_port=pub_sub_port)
+        client._init_fields(remote_host=host, req_rep_port=req_rep_port, pub_sub_port=pub_sub_port,
+                            log_event_queue_maxlen=log_event_queue_maxlen)
         client._init_connection()
         client._assert_connection_compat()
         return client

--- a/x64dbg_automate/__init__.py
+++ b/x64dbg_automate/__init__.py
@@ -22,7 +22,7 @@ if _IS_WINDOWS:
     from x64dbg_automate.win32 import GetTempPathW, SetConsoleCtrlHandler, EnumWindows, GetWindowTextW, GetWindowThreadProcessId
 
 
-COMPAT_VERSION = "lilac_bonnet" # TODO: externalize
+COMPAT_VERSION = "ghost_fungus" # TODO: externalize
 logger = logging.getLogger(__name__)
 all_instances: list['X64DbgClient'] = []
 

--- a/x64dbg_automate/commands_xauto.py
+++ b/x64dbg_automate/commands_xauto.py
@@ -437,20 +437,28 @@ class XAutoCommandsMixin(XAutoClientBase):
             ordinal=res[5]
         )
     
-    def get_log(self, since_index: int = 0) -> tuple[int, list[str]]:
+    def get_log(self, since_index: int = 0, limit: int = 0, filter: str = "") -> tuple[int, list[str], int, int]:
         """
         Retrieve log messages captured since the start of the current debug session.
 
         Args:
             since_index: Index returned by a previous call; pass 0 to get all messages
                          from the start of the session.
+            limit:       Maximum number of entries to return (0 = unlimited). Head
+                         semantics: the first `limit` matching entries are returned.
+                         remaining > 0 signals there are more; call again with next_index.
+            filter:      Substring to match against each log line. Only lines containing
+                         this string are returned. Empty string means no filtering.
 
         Returns:
-            A tuple of (next_index, messages). Pass next_index back on the next call
-            to receive only new messages since this one.
+            A tuple of (next_index, messages, remaining, evicted).
+            - next_index: pass as since_index on the next call to continue from here.
+            - remaining: matching entries not returned due to limit (0 = got everything).
+            - evicted: entries lost to buffer cap before since_index (gap in replayability).
         """
-        next_index, messages = self._send_request(XAutoCommand.XAUTO_REQ_GET_LOG, since_index)
-        return next_index, messages
+        next_index, messages, remaining, evicted = self._send_request(
+            XAutoCommand.XAUTO_REQ_GET_LOG, since_index, limit, filter)
+        return next_index, messages, remaining, evicted
 
     def wait_until_debugging(self, timeout: int = 10) -> bool:
         """

--- a/x64dbg_automate/commands_xauto.py
+++ b/x64dbg_automate/commands_xauto.py
@@ -34,6 +34,7 @@ class XAutoCommand(StrEnum):
     XAUTO_REQ_GET_LABEL = "XAUTO_REQ_GET_LABEL"
     XAUTO_REQ_GET_COMMENT = "XAUTO_REQ_GET_COMMENT"
     XAUTO_REQ_GET_SYMBOL = "XAUTO_REQ_GET_SYMBOL"
+    XAUTO_REQ_GET_LOG = "XAUTO_REQ_GET_LOG"
 
 
 class XAutoCommandsMixin(XAutoClientBase):
@@ -436,6 +437,21 @@ class XAutoCommandsMixin(XAutoClientBase):
             ordinal=res[5]
         )
     
+    def get_log(self, since_index: int = 0) -> tuple[int, list[str]]:
+        """
+        Retrieve log messages captured since the start of the current debug session.
+
+        Args:
+            since_index: Index returned by a previous call; pass 0 to get all messages
+                         from the start of the session.
+
+        Returns:
+            A tuple of (next_index, messages). Pass next_index back on the next call
+            to receive only new messages since this one.
+        """
+        next_index, messages = self._send_request(XAutoCommand.XAUTO_REQ_GET_LOG, since_index)
+        return next_index, messages
+
     def wait_until_debugging(self, timeout: int = 10) -> bool:
         """
         Blocks until the debugger enters a debugging state

--- a/x64dbg_automate/events.py
+++ b/x64dbg_automate/events.py
@@ -1,7 +1,13 @@
+from collections import deque
 from enum import StrEnum
 import time
 
 from pydantic import BaseModel
+
+
+# Default ring-buffer caps for the client-side event queues.
+DEFAULT_EVENT_QUEUE_MAXLEN = 100        # all events except EVENT_LOG_MESSAGE
+DEFAULT_LOG_EVENT_QUEUE_MAXLEN = 1000   # EVENT_LOG_MESSAGE only (higher volume)
 
 
 class EventType(StrEnum):
@@ -108,13 +114,17 @@ class ExitProcessEventData(BaseModel):
 
 
 class LogMessageEventData(BaseModel):
+    """
+    Payload of an `EVENT_LOG_MESSAGE` event: a single line written to the x64dbg
+    log, captured by the plugin's log hook and published as it occurs. The same
+    lines are also retrievable on demand via `X64DbgClient.get_log`.
+    """
     text: str
 
 
 EventTypes = BreakpointEventData | SysBreakpointEventData | CreateThreadEventData | ExitThreadEventData | \
     LoadDllEventData | UnloadDllEventData | OutputDebugStringEventData | ExceptionEventData | AttachEventData | \
-    DetachEventData | InitDebugEventData | CreateProcessEventData | ExitProcessEventData | \
-    LogMessageEventData | None
+    DetachEventData | InitDebugEventData | CreateProcessEventData | ExitProcessEventData | LogMessageEventData | None
 
 
 class DbgEvent():
@@ -224,48 +234,107 @@ class DbgEvent():
 
 
 class DebugEventQueueMixin():
-    _debug_events_q: list[DbgEvent] = []
-    listeners: dict[EventType, list[callable]] = {}
+    """
+    Receives debug events published by the plugin over the PUB/SUB channel and
+    exposes them via polling (`get_latest_debug_event`, `wait_for_debug_event`)
+    and callbacks (`watch_debug_event`).
+
+    `EVENT_LOG_MESSAGE` events are held in a SEPARATE bounded queue from all other
+    debug events. A verbose log stream (e.g. a long trace) can produce far more
+    log events than the main queue would hold; keeping them apart guarantees they
+    can never evict breakpoint / step / other control events that a caller is
+    waiting on. Both queues are bounded ring buffers — the oldest entry is dropped
+    once the cap is reached. The log-queue cap is configurable
+    (`log_event_queue_maxlen`); the main queue uses `DEFAULT_EVENT_QUEUE_MAXLEN`.
+    """
+    _debug_events_q: deque   # all events EXCEPT EVENT_LOG_MESSAGE
+    _log_events_q: deque     # EVENT_LOG_MESSAGE only
+    listeners: dict
+
+    def __init__(self):
+        # Direct instantiation (e.g. tests). X64DbgClient initializes via
+        # _init_fields -> _init_event_queues instead.
+        self._init_event_queues()
+
+    def _init_event_queues(self, log_event_queue_maxlen: int = DEFAULT_LOG_EVENT_QUEUE_MAXLEN) -> None:
+        """(Re)create the per-instance event queues. Instance-level so separate
+        clients never share queue state."""
+        self._debug_events_q = deque(maxlen=DEFAULT_EVENT_QUEUE_MAXLEN)
+        self._log_events_q = deque(maxlen=log_event_queue_maxlen)
+        self.listeners = {}
+
+    @property
+    def log_event_queue_maxlen(self) -> int:
+        """Maximum number of `EVENT_LOG_MESSAGE` events retained in the log queue.
+
+        Assigning a new value resizes the queue in place, keeping the most recent
+        events when the new cap is smaller.
+
+        Memory footprint is roughly ``maxlen x average payload size``. Most log
+        lines are small, but x64dbg batches trace output into large multi-line
+        chunks (tens of KB each), so a sustained trace can approach
+        ``maxlen x ~tens-of-KB``. Lower this cap if that ceiling matters; the
+        pull-based `get_log` buffer is the preferred way to consume bulk trace log.
+        """
+        return self._log_events_q.maxlen
+
+    @log_event_queue_maxlen.setter
+    def log_event_queue_maxlen(self, maxlen: int) -> None:
+        self._log_events_q = deque(self._log_events_q, maxlen=maxlen)
+
+    def _queue_for(self, event_type: EventType) -> deque:
+        if event_type == EventType.EVENT_LOG_MESSAGE:
+            return self._log_events_q
+        return self._debug_events_q
 
     def debug_event_publish(self, raw_event_data: list[any]):
         event = DbgEvent(raw_event_data[0], raw_event_data[1:])
-        while len(self._debug_events_q) > 100:
-            self._debug_events_q.pop(0)
-        self._debug_events_q.append(event)
+        # deque(maxlen=...) drops the oldest entry automatically once full.
+        self._queue_for(event.event_type).append(event)
         for listener in self.listeners.get(event.event_type, []):
             listener(event)
         return event
-    
+
     def get_latest_debug_event(self) -> DbgEvent | None:
         """
         Get the latest debug event that occurred in the debugee. The event is removed from the queue.
+
+        Note: `EVENT_LOG_MESSAGE` events are kept in a separate queue and are not
+        returned here. Retrieve them with `wait_for_debug_event(EventType.EVENT_LOG_MESSAGE)`,
+        a `watch_debug_event` callback, or the `get_log` buffer.
         """
         if len(self._debug_events_q) == 0:
             return None
         return self._debug_events_q.pop()
-    
+
     def peek_latest_debug_event(self) -> DbgEvent | None:
         """
         Get the latest debug event that occurred in the debugee. The event is not removed from the queue.
+
+        Note: `EVENT_LOG_MESSAGE` events are kept in a separate queue and are not returned here (see `get_latest_debug_event`).
         """
         if len(self._debug_events_q) == 0:
             return None
         return self._debug_events_q[-1]
-    
+
     def clear_debug_events(self, event_type: EventType | None = None) -> None:
         """
-        Clear the debug event queue. If `event_type` is specified, only events of that type will be removed.
-        
+        Clear buffered debug events. If `event_type` is specified, only events of that
+        type are removed (from whichever queue holds them); otherwise both the main
+        event queue and the `EVENT_LOG_MESSAGE` queue are cleared.
+
         Args:
             event_type: The type of event to clear. If None, all events will be cleared.
         """
-        filtered = []
-        for _ in range(len(self._debug_events_q)):
-            event = self._debug_events_q.pop(0)
-            if event.event_type != event_type and event_type is not None:
-                filtered.append(event)
-        self._debug_events_q = filtered
-    
+        if event_type is None:
+            self._debug_events_q.clear()
+            self._log_events_q.clear()
+            return
+        q = self._queue_for(event_type)
+        kept = [e for e in list(q) if e.event_type != event_type]
+        q.clear()
+        q.extend(kept)
+
     def wait_for_debug_event(self, event_type: EventType, timeout: int = 5) -> DbgEvent | None:
         """
         Wait for a debug event of a specific type to occur. This method returns the latest event of the specified type, which may have occurred before the method was called.
@@ -281,14 +350,20 @@ class DebugEventQueueMixin():
         Returns:
             DbgEvent | None: The latest event of the specified type, or None if the event did not occur within the timeout.
         """
+        q = self._queue_for(event_type)
         while timeout > 0:
-            for ix, event in enumerate(self._debug_events_q):
+            # Iterate a snapshot: the SUB thread may append/evict concurrently.
+            for event in list(q):
                 if event.event_type == event_type:
-                    return self._debug_events_q.pop(ix)
+                    try:
+                        q.remove(event)
+                    except ValueError:
+                        pass  # already evicted by the cap between snapshot and removal
+                    return event
             time.sleep(0.25)
             timeout -= 0.25
         return None
-    
+
     def watch_debug_event(self, event_type: EventType, callback: callable):
         """
         Register a callback to be invoked when a debug event of a specific type occurs.

--- a/x64dbg_automate/events.py
+++ b/x64dbg_automate/events.py
@@ -22,6 +22,7 @@ class EventType(StrEnum):
     EVENT_STOP_DEBUG = "EVENT_STOP_DEBUG"
     EVENT_CREATE_PROCESS = "EVENT_CREATE_PROCESS"
     EVENT_EXIT_PROCESS = "EVENT_EXIT_PROCESS"
+    EVENT_LOG_MESSAGE = "EVENT_LOG_MESSAGE"
 
 
 class BreakpointEventData(BaseModel):
@@ -106,9 +107,14 @@ class ExitProcessEventData(BaseModel):
     dwExitCode: int
 
 
+class LogMessageEventData(BaseModel):
+    text: str
+
+
 EventTypes = BreakpointEventData | SysBreakpointEventData | CreateThreadEventData | ExitThreadEventData | \
     LoadDllEventData | UnloadDllEventData | OutputDebugStringEventData | ExceptionEventData | AttachEventData | \
-    DetachEventData | InitDebugEventData | CreateProcessEventData | ExitProcessEventData | None
+    DetachEventData | InitDebugEventData | CreateProcessEventData | ExitProcessEventData | \
+    LogMessageEventData | None
 
 
 class DbgEvent():
@@ -198,6 +204,10 @@ class DbgEvent():
         elif event_type == EventType.EVENT_EXIT_PROCESS:
             self.event_data = ExitProcessEventData(
                 dwExitCode=event_data[0]
+            )
+        elif event_type == EventType.EVENT_LOG_MESSAGE:
+            self.event_data = LogMessageEventData(
+                text=event_data[0]
             )
         elif event_type == EventType.EVENT_EXCEPTION:
             self.event_data = ExceptionEventData(

--- a/x64dbg_automate/mcp_server.py
+++ b/x64dbg_automate/mcp_server.py
@@ -1145,6 +1145,30 @@ def log_message(message: str) -> str:
 
 
 @mcp.tool()
+def get_log(since_index: int = 0) -> str:
+    """Read log messages from the current debug session.
+
+    Returns all messages captured since the session started, or only new messages
+    when since_index from a previous call is provided.
+
+    Args:
+        since_index: Index returned by a previous get_log call (0 for full session log)
+
+    Returns:
+        Log lines followed by the next_index value to use on the next call.
+    """
+    try:
+        client = _require_client()
+        next_index, messages = client.get_log(since_index)
+        if not messages:
+            return f"No new log messages. next_index={next_index}"
+        body = "\n".join(m.rstrip("\n") for m in messages)
+        return f"{body}\n[next_index={next_index}]"
+    except Exception as e:
+        return f"Error: {e}"
+
+
+@mcp.tool()
 def refresh_gui() -> str:
     """Refresh all x64dbg GUI views."""
     try:

--- a/x64dbg_automate/mcp_server.py
+++ b/x64dbg_automate/mcp_server.py
@@ -1145,25 +1145,43 @@ def log_message(message: str) -> str:
 
 
 @mcp.tool()
-def get_log(since_index: int = 0) -> str:
+def get_log(since_index: int = 0, limit: int = 0, filter: str = "") -> str:
     """Read log messages from the current debug session.
 
     Returns all messages captured since the session started, or only new messages
-    when since_index from a previous call is provided.
+    when since_index from a previous call is provided. Head semantics: when limit
+    is set, the first `limit` matching entries are returned. Call again with the
+    returned next_index to fetch the next page.
 
     Args:
         since_index: Index returned by a previous get_log call (0 for full session log)
+        limit:       Maximum number of log lines to return (0 = unlimited). When set,
+                     the first `limit` matching lines are returned (head semantics).
+                     If remaining > 0, call again with next_index to get the next page.
+        filter:      Substring to match against each log line — only matching lines are
+                     returned. Empty string means no filtering.
 
     Returns:
-        Log lines followed by the next_index value to use on the next call.
+        Log lines followed by metadata:
+        - [next_index=N] always present; pass as since_index on the next call.
+        - [remaining=N, call again with next_index=N] when more entries exist.
+        - [WARNING: evicted=N entries lost before oldest available] when buffer cap
+          was hit and the requested since_index is older than the oldest entry.
     """
     try:
         client = _require_client()
-        next_index, messages = client.get_log(since_index)
+        next_index, messages, remaining, evicted = client.get_log(since_index, limit, filter)
+        parts = []
+        if evicted:
+            parts.append(f"[WARNING: evicted={evicted} entries lost before oldest available]")
         if not messages:
-            return f"No new log messages. next_index={next_index}"
-        body = "\n".join(m.rstrip("\n") for m in messages)
-        return f"{body}\n[next_index={next_index}]"
+            parts.append(f"No new log messages. next_index={next_index}")
+            return "\n".join(parts)
+        parts.append("\n".join(m.rstrip("\n") for m in messages))
+        if remaining:
+            parts.append(f"[remaining={remaining}, call again with next_index={next_index}]")
+        parts.append(f"[next_index={next_index}]")
+        return "\n".join(parts)
     except Exception as e:
         return f"Error: {e}"
 


### PR DESCRIPTION
- events: EVENT_LOG_MESSAGE type + LogMessageEventData(text) model, wired into DbgEvent dispatch
- commands_xauto: XAUTO_REQ_GET_LOG command + get_log(since_index) returning (next_index, [str]) for incremental polling
- mcp_server: get_log MCP tool with since_index parameter