### PR TITLE
Add log capture client support (get_log + EVENT_LOG_MESSAGE)

### DIFF
--- a/docs/api/debug-control.md
+++ b/docs/api/debug-control.md
@@ -298,6 +298,12 @@ client.detach_session()
         show_root_full_path: false
 
 
+::: x64dbg_automate.X64DbgClient.get_log
+    options:
+        show_root_heading: true
+        show_root_full_path: false
+
+
 ### API Model Reference
 
 ::: x64dbg_automate.events.DbgEvent
@@ -308,6 +314,13 @@ client.detach_session()
 
 
 ::: x64dbg_automate.events.EventType
+    options:
+        show_root_heading: true
+        show_root_full_path: false
+        show_bases: false
+
+
+::: x64dbg_automate.events.LogMessageEventData
     options:
         show_root_heading: true
         show_root_full_path: false

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -93,7 +93,7 @@ The MCP server provides ~40 tools organized into the following groups:
 | Threads | `create_thread`, `terminate_thread`, `pause_resume_thread`, `switch_thread` | Thread management |
 | Events | `get_latest_event`, `wait_for_event` | Debug event queue |
 | Settings | `get_setting`, `set_setting` | x64dbg configuration |
-| GUI | `log_message`, `refresh_gui` | Debugger UI interaction |
+| GUI | `log_message`, `get_log`, `refresh_gui` | Debugger UI interaction, log capture |
 
 ### Remote Debugging (VM / Network)
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -38,3 +38,76 @@ def test_log_message_event_dispatch_and_watch():
         assert received[0].event_data.message == "buffered line"
     finally:
         q.unwatch_debug_event(EventType.EVENT_LOG_MESSAGE, callback)
+
+
+def test_log_events_do_not_evict_other_events():
+    # A flood of EVENT_LOG_MESSAGE must not push a non-log event out of the main
+    # queue -- the whole point of the separate log queue.
+    q = DebugEventQueueMixin()
+    q._init_event_queues(log_event_queue_maxlen=5)
+
+    # one important non-log event
+    q.debug_event_publish(["EVENT_SYSTEMBREAKPOINT", 0])
+
+    # flood with far more log events than either cap
+    for i in range(50):
+        q.debug_event_publish(["EVENT_LOG_MESSAGE", f"line {i}"])
+
+    # the non-log event survived in its own (main) queue
+    ev = q.wait_for_debug_event(EventType.EVENT_SYSTEMBREAKPOINT, timeout=1)
+    assert ev is not None
+    assert ev.event_type == EventType.EVENT_SYSTEMBREAKPOINT
+
+    # the log queue is bounded to its cap and holds only the most recent lines
+    assert len(q._log_events_q) == 5
+    msgs = [e.event_data.message for e in q._log_events_q]
+    assert msgs == [f"line {i}" for i in range(45, 50)]
+
+
+def test_log_event_queue_maxlen_configurable_and_resizable():
+    q = DebugEventQueueMixin()
+    q._init_event_queues(log_event_queue_maxlen=3)
+    assert q.log_event_queue_maxlen == 3
+
+    for i in range(10):
+        q.debug_event_publish(["EVENT_LOG_MESSAGE", str(i)])
+    assert len(q._log_events_q) == 3
+    assert [e.event_data.message for e in q._log_events_q] == ["7", "8", "9"]
+
+    # shrinking the cap keeps the most recent events
+    q.log_event_queue_maxlen = 2
+    assert q.log_event_queue_maxlen == 2
+    assert [e.event_data.message for e in q._log_events_q] == ["8", "9"]
+
+
+def test_clear_debug_events_targets_correct_queue():
+    q = DebugEventQueueMixin()
+    q._init_event_queues()
+    q.debug_event_publish(["EVENT_SYSTEMBREAKPOINT", 0])
+    q.debug_event_publish(["EVENT_LOG_MESSAGE", "a"])
+
+    # clearing only log events leaves the main queue intact
+    q.clear_debug_events(EventType.EVENT_LOG_MESSAGE)
+    assert len(q._log_events_q) == 0
+    assert q.peek_latest_debug_event().event_type == EventType.EVENT_SYSTEMBREAKPOINT
+
+    # clearing everything empties both
+    q.debug_event_publish(["EVENT_LOG_MESSAGE", "b"])
+    q.clear_debug_events()
+    assert len(q._log_events_q) == 0
+    assert len(q._debug_events_q) == 0
+
+
+def test_get_latest_excludes_log_events():
+    q = DebugEventQueueMixin()
+    q._init_event_queues()
+    q.debug_event_publish(["EVENT_SYSTEMBREAKPOINT", 0])
+    q.debug_event_publish(["EVENT_LOG_MESSAGE", "noise"])
+
+    # get_latest / peek operate on the main queue only; log noise never masks
+    # the real event.
+    assert q.peek_latest_debug_event().event_type == EventType.EVENT_SYSTEMBREAKPOINT
+    assert q.get_latest_debug_event().event_type == EventType.EVENT_SYSTEMBREAKPOINT
+    assert q.get_latest_debug_event() is None  # main queue now empty
+    # the log event is still retrievable from its own queue
+    assert q.wait_for_debug_event(EventType.EVENT_LOG_MESSAGE, timeout=1).event_data.message == "noise"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,40 @@
+"""
+Pure unit tests for debug-event parsing. These do not require a live x64dbg
+instance and exercise the wire-shape -> typed-model mapping in events.py.
+"""
+from x64dbg_automate.events import (
+    DbgEvent,
+    DebugEventQueueMixin,
+    EventType,
+    LogMessageEventData,
+)
+
+
+def test_log_message_event_parsing():
+    # DbgEvent receives the event type and the trailing argument tuple, so the
+    # message published by the plugin as ("EVENT_LOG_MESSAGE", msg) arrives here
+    # as event_data[0].
+    event = DbgEvent(EventType.EVENT_LOG_MESSAGE, ["hello from x64dbg"])
+    assert event.event_type == EventType.EVENT_LOG_MESSAGE
+    assert isinstance(event.event_data, LogMessageEventData)
+    assert event.event_data.message == "hello from x64dbg"
+
+
+def test_log_message_event_dispatch_and_watch():
+    class Queue(DebugEventQueueMixin):
+        pass
+
+    q = Queue()
+    received: list[DbgEvent] = []
+
+    callback = lambda e: received.append(e)
+    q.watch_debug_event(EventType.EVENT_LOG_MESSAGE, callback)
+    try:
+        # debug_event_publish consumes the raw wire list: [type, *args]
+        event = q.debug_event_publish(["EVENT_LOG_MESSAGE", "buffered line"])
+        assert event.event_type == EventType.EVENT_LOG_MESSAGE
+        assert event.event_data.message == "buffered line"
+        assert len(received) == 1
+        assert received[0].event_data.message == "buffered line"
+    finally:
+        q.unwatch_debug_event(EventType.EVENT_LOG_MESSAGE, callback)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -855,6 +855,36 @@ class TestGui:
         result = mcp_mod.refresh_gui()
         assert "refreshed" in result.lower()
 
+    def test_get_log_returns_lines_and_next_index(self, mock_client):
+        mock_client.get_log.return_value = (12, ["line a", "line b"], 0, 0)
+        result = mcp_mod.get_log()
+        assert "line a" in result and "line b" in result
+        assert "Next index: 12" in result
+        # default args forwarded to the client (since_index, limit, filter_str)
+        mock_client.get_log.assert_called_once_with(0, 0, "")
+
+    def test_get_log_empty(self, mock_client):
+        mock_client.get_log.return_value = (5, [], 0, 0)
+        result = mcp_mod.get_log(since_index=5)
+        assert "No new log lines" in result
+        assert "Next index: 5" in result
+
+    def test_get_log_passes_limit_and_filter(self, mock_client):
+        mock_client.get_log.return_value = (3, ["x"], 0, 0)
+        mcp_mod.get_log(since_index=1, limit=2, filter_str="foo")
+        mock_client.get_log.assert_called_once_with(1, 2, "foo")
+
+    def test_get_log_notes_remaining_and_evicted(self, mock_client):
+        mock_client.get_log.return_value = (9, ["partial"], 4, 7)
+        result = mcp_mod.get_log(limit=1)
+        assert "4 more matching entries remaining" in result
+        assert "7 entries evicted before since_index" in result
+
+    def test_get_log_error(self, mock_client):
+        mock_client.get_log.side_effect = RuntimeError("boom")
+        result = mcp_mod.get_log()
+        assert "Error" in result
+
 
 # ---------------------------------------------------------------------------
 # Error path tests

--- a/tests/test_xauto_commands.py
+++ b/tests/test_xauto_commands.py
@@ -192,3 +192,31 @@ def test_get_symbol_at_exists(client: X64DbgClient):
     assert symbol.undecoratedSymbol == ''
     assert symbol.type == 1
 
+
+def test_get_log_incremental(client: X64DbgClient):
+    client.start_session(r'c:\Windows\system32\winver.exe')
+    next_index, lines = client.get_log()
+    assert isinstance(next_index, int)
+    assert isinstance(lines, list)
+
+    marker = "xauto-test-log-marker"
+    client.log(marker)
+    client.wait_cmd_ready()
+
+    new_index, new_lines = client.get_log(next_index)
+    # Incremental poll returns only lines added since next_index, and the index
+    # advances monotonically.
+    assert new_index >= next_index
+    assert any(marker in line for line in new_lines)
+
+
+def test_log_message_event_delivered(client: X64DbgClient):
+    client.start_session(r'c:\Windows\system32\winver.exe')
+    client.clear_debug_events(EventType.EVENT_LOG_MESSAGE)
+
+    client.log("xauto-test-event-marker")
+    event = client.wait_for_debug_event(EventType.EVENT_LOG_MESSAGE, timeout=5)
+    assert event is not None
+    assert event.event_type == EventType.EVENT_LOG_MESSAGE
+    assert isinstance(event.event_data.message, str)
+

--- a/tests/test_xauto_commands.py
+++ b/tests/test_xauto_commands.py
@@ -1,4 +1,5 @@
 import queue
+import time
 from tests.conftest import TEST_BITNESS
 from x64dbg_automate import X64DbgClient
 from x64dbg_automate.events import DbgEvent, EventType
@@ -195,19 +196,76 @@ def test_get_symbol_at_exists(client: X64DbgClient):
 
 def test_get_log_incremental(client: X64DbgClient):
     client.start_session(r'c:\Windows\system32\winver.exe')
-    next_index, lines = client.get_log()
+    next_index, lines, remaining, evicted = client.get_log()
     assert isinstance(next_index, int)
     assert isinstance(lines, list)
+    assert isinstance(remaining, int)
+    assert isinstance(evicted, int)
 
     marker = "xauto-test-log-marker"
     client.log(marker)
     client.wait_cmd_ready()
 
-    new_index, new_lines = client.get_log(next_index)
+    # Log capture is asynchronous; poll the incremental read until the marker lands.
+    deadline = time.time() + 5
+    new_index, new_lines = next_index, []
+    while time.time() < deadline:
+        new_index, new_lines, _, _ = client.get_log(next_index)
+        if any(marker in entry for entry in new_lines):
+            break
+        time.sleep(0.2)
+
     # Incremental poll returns only lines added since next_index, and the index
     # advances monotonically.
     assert new_index >= next_index
-    assert any(marker in line for line in new_lines)
+    assert any(marker in entry for entry in new_lines)
+
+
+def test_get_log_filter_and_limit(client: X64DbgClient):
+    client.start_session(r'c:\Windows\system32\winver.exe')
+
+    base = "xauto-filter-precise"               # token we filter on
+    control = "xauto-filter-control-excluded"   # logged but must NOT match `base`
+    n = 4
+
+    client.log(control)
+    for i in range(n):
+        client.log(f"{base}-{i}")
+    client.wait_cmd_ready()
+
+    # x64dbg coalesces rapid log writes into a single multi-line entry, and capture
+    # is asynchronous, so poll until our lines land. Filtering is LINE-level within
+    # an entry, so assert on flattened lines rather than on entry count.
+    def base_lines():
+        _, matched, full_remaining, _ = client.get_log(0, filter_str=base)
+        lines = [ln for entry in matched for ln in entry.splitlines()]
+        return lines, full_remaining
+
+    deadline = time.time() + 5
+    lines, full_remaining = base_lines()
+    while sum(base in ln for ln in lines) < n and time.time() < deadline:
+        time.sleep(0.2)
+        lines, full_remaining = base_lines()
+
+    assert full_remaining == 0                          # no limit -> nothing held back
+    assert sum(base in ln for ln in lines) == n         # every base line returned
+    assert all(control not in ln for ln in lines)       # control line stripped (line-level filter)
+
+    # `limit` caps the number of ENTRIES (not lines) and reports the rest as
+    # `remaining`; verified against an unlimited read. Session startup reliably
+    # emits several distinct log entries, so there is always >1 entry to split on.
+    _, full, rem_full, _ = client.get_log(0)
+    total = len(full)
+    assert total >= 2 and rem_full == 0
+
+    next_index, head, remaining, _ = client.get_log(0, limit=1)
+    assert len(head) == 1
+    assert remaining == total - 1
+
+    # Draining from the returned cursor fetches exactly the held-back entries.
+    _, rest, rest_remaining, _ = client.get_log(next_index)
+    assert len(rest) == remaining
+    assert rest_remaining == 0
 
 
 def test_log_message_event_delivered(client: X64DbgClient):

--- a/x64dbg_automate/__init__.py
+++ b/x64dbg_automate/__init__.py
@@ -12,7 +12,7 @@ import psutil
 import shutil
 import zmq
 
-from x64dbg_automate.events import DebugEventQueueMixin
+from x64dbg_automate.events import DebugEventQueueMixin, DEFAULT_LOG_EVENT_QUEUE_MAXLEN
 from x64dbg_automate.hla_xauto import XAutoHighLevelCommandAbstractionMixin
 from x64dbg_automate.models import DebugSession
 
@@ -44,7 +44,8 @@ class ClientConnectionFailedError(Exception):
 
 class X64DbgClient(XAutoHighLevelCommandAbstractionMixin, DebugEventQueueMixin):
     def _init_fields(self, x64dbg_path: str | None = None, remote_host: str = "localhost",
-                     req_rep_port: int = 0, pub_sub_port: int = 0):
+                     req_rep_port: int = 0, pub_sub_port: int = 0,
+                     log_event_queue_maxlen: int = DEFAULT_LOG_EVENT_QUEUE_MAXLEN):
         self.x64dbg_path = x64dbg_path
         self.proc = None
         self.session_pid = None
@@ -55,18 +56,30 @@ class X64DbgClient(XAutoHighLevelCommandAbstractionMixin, DebugEventQueueMixin):
         self.sess_pub_sub_port = pub_sub_port
         self.remote_host = remote_host
         self._req_lock = threading.Lock()
+        self._init_event_queues(log_event_queue_maxlen)
         all_instances.append(self)
 
-    def __init__(self, x64dbg_path: str = "x64dbg"):
+    def __init__(self, x64dbg_path: str = "x64dbg",
+                 log_event_queue_maxlen: int = DEFAULT_LOG_EVENT_QUEUE_MAXLEN):
+        """
+        Args:
+            x64dbg_path: Path to the x64dbg executable (or a name resolvable on PATH).
+            log_event_queue_maxlen: Maximum number of `EVENT_LOG_MESSAGE` events
+                retained in the dedicated log-event queue. Log events are kept
+                separate from other debug events so a verbose log stream (e.g. a
+                trace) cannot evict breakpoint/step events. Can also be changed
+                later via the `log_event_queue_maxlen` property.
+        """
         resolved = x64dbg_path
         if not Path(resolved).is_file():
             resolved = shutil.which(x64dbg_path)
         if resolved is None or not Path(resolved).is_file():
             raise FileNotFoundError(f"x64dbg executable not found at {x64dbg_path} or in PATH")
-        self._init_fields(x64dbg_path=resolved)
+        self._init_fields(x64dbg_path=resolved, log_event_queue_maxlen=log_event_queue_maxlen)
 
     @classmethod
-    def connect_remote(cls, host: str, req_rep_port: int, pub_sub_port: int) -> 'X64DbgClient':
+    def connect_remote(cls, host: str, req_rep_port: int, pub_sub_port: int,
+                       log_event_queue_maxlen: int = DEFAULT_LOG_EVENT_QUEUE_MAXLEN) -> 'X64DbgClient':
         """Connect to a remote x64dbg instance by host and port pair.
 
         This bypasses local session discovery (lockfiles) and connects directly
@@ -76,12 +89,15 @@ class X64DbgClient(XAutoHighLevelCommandAbstractionMixin, DebugEventQueueMixin):
             host: Remote hostname or IP address (e.g. '192.168.1.100')
             req_rep_port: The REQ/REP port the plugin is listening on
             pub_sub_port: The PUB/SUB port the plugin is listening on
+            log_event_queue_maxlen: Maximum number of `EVENT_LOG_MESSAGE` events
+                retained in the dedicated log-event queue (see `__init__`).
 
         Returns:
             A connected X64DbgClient instance
         """
         client = cls.__new__(cls)
-        client._init_fields(remote_host=host, req_rep_port=req_rep_port, pub_sub_port=pub_sub_port)
+        client._init_fields(remote_host=host, req_rep_port=req_rep_port, pub_sub_port=pub_sub_port,
+                            log_event_queue_maxlen=log_event_queue_maxlen)
         client._init_connection()
         client._assert_connection_compat()
         return client

--- a/x64dbg_automate/__init__.py
+++ b/x64dbg_automate/__init__.py
@@ -22,7 +22,7 @@ if _IS_WINDOWS:
     from x64dbg_automate.win32 import GetTempPathW, SetConsoleCtrlHandler, EnumWindows, GetWindowTextW, GetWindowThreadProcessId
 
 
-COMPAT_VERSION = "lilac_bonnet" # TODO: externalize
+COMPAT_VERSION = "ghost_fungus" # TODO: externalize
 logger = logging.getLogger(__name__)
 all_instances: list['X64DbgClient'] = []
 

--- a/x64dbg_automate/commands_xauto.py
+++ b/x64dbg_automate/commands_xauto.py
@@ -437,28 +437,61 @@ class XAutoCommandsMixin(XAutoClientBase):
             ordinal=res[5]
         )
 
-    def get_log(self, since_index: int = 0) -> tuple[int, list[str]]:
+    def get_log(
+        self,
+        since_index: int = 0,
+        limit: int = 0,
+        filter_str: str = "",
+    ) -> tuple[int, list[str], int, int]:
         """
         Retrieves x64dbg log lines captured since a given index.
 
         The plugin maintains a bounded, monotonically-indexed buffer of every log
         line x64dbg emits (capped at the most recent entries; older lines are
         evicted). Pass the `next_index` returned by a previous call to poll only
-        for lines added since then. The buffer is cleared at the start of each
-        debug session.
+        for lines added since then.
+
+        The index is monotonic only *within* a single debug session: the buffer
+        and its index are reset when a new session starts, so a `next_index`
+        carried over from a previous session snaps back to the start of the new
+        session's log rather than continuing forward. Treat the cursor as
+        per-session.
+
+        `limit` and `filter_str` bound the amount of text returned for verbose
+        sessions. Filtering is applied at the line level — only lines containing
+        `filter_str` are kept, and entries with no matching lines are omitted —
+        and at most `limit` matching entries are returned per call ("head"
+        semantics, oldest first). When the result is truncated, `remaining` is
+        non-zero and `next_index` points just past the last returned entry, so a
+        follow-up call with `since_index=next_index` continues where this one
+        stopped.
 
         Args:
             since_index: Return only lines at or after this index. Use 0 to
                 retrieve everything currently buffered. If `since_index` predates
-                the oldest retained line, retrieval resumes from the oldest line.
+                the oldest retained line, retrieval resumes from the oldest line
+                and `evicted` reports how many lines were skipped.
+            limit: Maximum number of matching entries to return. 0 means no limit.
+            filter_str: Substring to filter log lines by. Only lines containing
+                this string are returned (case-sensitive plain substring — not a
+                regular expression); entries with no matching lines are omitted.
+                Empty string means no filtering.
 
         Returns:
-            A tuple of `(next_index, lines)` where `next_index` is the index to
-            pass on the next call to continue where this one left off, and `lines`
-            is the list of captured log lines.
+            A tuple of `(next_index, lines, remaining, evicted)`:
+                next_index: index to pass as `since_index` on the next call to
+                    continue where this one left off.
+                lines: the list of captured log lines.
+                remaining: matching entries beyond those returned (non-zero only
+                    when `limit` truncated the result); call again with
+                    `since_index=next_index` to fetch them.
+                evicted: entries between the requested `since_index` and the oldest
+                    still-buffered line, lost to the buffer cap.
         """
-        next_index, lines = self._send_request(XAutoCommand.XAUTO_REQ_GET_LOG, since_index)
-        return next_index, lines
+        next_index, lines, remaining, evicted = self._send_request(
+            XAutoCommand.XAUTO_REQ_GET_LOG, since_index, limit, filter_str
+        )
+        return next_index, list(lines), remaining, evicted
 
     def wait_until_debugging(self, timeout: int = 10) -> bool:
         """

--- a/x64dbg_automate/commands_xauto.py
+++ b/x64dbg_automate/commands_xauto.py
@@ -34,6 +34,7 @@ class XAutoCommand(StrEnum):
     XAUTO_REQ_GET_LABEL = "XAUTO_REQ_GET_LABEL"
     XAUTO_REQ_GET_COMMENT = "XAUTO_REQ_GET_COMMENT"
     XAUTO_REQ_GET_SYMBOL = "XAUTO_REQ_GET_SYMBOL"
+    XAUTO_REQ_GET_LOG = "XAUTO_REQ_GET_LOG"
 
 
 class XAutoCommandsMixin(XAutoClientBase):
@@ -435,7 +436,30 @@ class XAutoCommandsMixin(XAutoClientBase):
             type=SymbolType(res[4]),
             ordinal=res[5]
         )
-    
+
+    def get_log(self, since_index: int = 0) -> tuple[int, list[str]]:
+        """
+        Retrieves x64dbg log lines captured since a given index.
+
+        The plugin maintains a bounded, monotonically-indexed buffer of every log
+        line x64dbg emits (capped at the most recent entries; older lines are
+        evicted). Pass the `next_index` returned by a previous call to poll only
+        for lines added since then. The buffer is cleared at the start of each
+        debug session.
+
+        Args:
+            since_index: Return only lines at or after this index. Use 0 to
+                retrieve everything currently buffered. If `since_index` predates
+                the oldest retained line, retrieval resumes from the oldest line.
+
+        Returns:
+            A tuple of `(next_index, lines)` where `next_index` is the index to
+            pass on the next call to continue where this one left off, and `lines`
+            is the list of captured log lines.
+        """
+        next_index, lines = self._send_request(XAutoCommand.XAUTO_REQ_GET_LOG, since_index)
+        return next_index, lines
+
     def wait_until_debugging(self, timeout: int = 10) -> bool:
         """
         Blocks until the debugger enters a debugging state

--- a/x64dbg_automate/events.py
+++ b/x64dbg_automate/events.py
@@ -1,7 +1,13 @@
+from collections import deque
 from enum import StrEnum
 import time
 
 from pydantic import BaseModel
+
+
+# Default ring-buffer caps for the client-side event queues.
+DEFAULT_EVENT_QUEUE_MAXLEN = 100        # all events except EVENT_LOG_MESSAGE
+DEFAULT_LOG_EVENT_QUEUE_MAXLEN = 1000   # EVENT_LOG_MESSAGE only (higher volume)
 
 
 class EventType(StrEnum):
@@ -108,6 +114,11 @@ class ExitProcessEventData(BaseModel):
 
 
 class LogMessageEventData(BaseModel):
+    """
+    Payload of an `EVENT_LOG_MESSAGE` event: a single line written to the x64dbg
+    log, captured by the plugin's log hook and published as it occurs. The same
+    lines are also retrievable on demand via `X64DbgClient.get_log`.
+    """
     message: str
 
 
@@ -223,48 +234,107 @@ class DbgEvent():
 
 
 class DebugEventQueueMixin():
-    _debug_events_q: list[DbgEvent] = []
-    listeners: dict[EventType, list[callable]] = {}
+    """
+    Receives debug events published by the plugin over the PUB/SUB channel and
+    exposes them via polling (`get_latest_debug_event`, `wait_for_debug_event`)
+    and callbacks (`watch_debug_event`).
+
+    `EVENT_LOG_MESSAGE` events are held in a SEPARATE bounded queue from all other
+    debug events. A verbose log stream (e.g. a long trace) can produce far more
+    log events than the main queue would hold; keeping them apart guarantees they
+    can never evict breakpoint / step / other control events that a caller is
+    waiting on. Both queues are bounded ring buffers — the oldest entry is dropped
+    once the cap is reached. The log-queue cap is configurable
+    (`log_event_queue_maxlen`); the main queue uses `DEFAULT_EVENT_QUEUE_MAXLEN`.
+    """
+    _debug_events_q: deque   # all events EXCEPT EVENT_LOG_MESSAGE
+    _log_events_q: deque     # EVENT_LOG_MESSAGE only
+    listeners: dict
+
+    def __init__(self):
+        # Direct instantiation (e.g. tests). X64DbgClient initializes via
+        # _init_fields -> _init_event_queues instead.
+        self._init_event_queues()
+
+    def _init_event_queues(self, log_event_queue_maxlen: int = DEFAULT_LOG_EVENT_QUEUE_MAXLEN) -> None:
+        """(Re)create the per-instance event queues. Instance-level so separate
+        clients never share queue state."""
+        self._debug_events_q = deque(maxlen=DEFAULT_EVENT_QUEUE_MAXLEN)
+        self._log_events_q = deque(maxlen=log_event_queue_maxlen)
+        self.listeners = {}
+
+    @property
+    def log_event_queue_maxlen(self) -> int:
+        """Maximum number of `EVENT_LOG_MESSAGE` events retained in the log queue.
+
+        Assigning a new value resizes the queue in place, keeping the most recent
+        events when the new cap is smaller.
+
+        Memory footprint is roughly ``maxlen x average payload size``. Most log
+        lines are small, but x64dbg batches trace output into large multi-line
+        chunks (tens of KB each), so a sustained trace can approach
+        ``maxlen x ~tens-of-KB``. Lower this cap if that ceiling matters; the
+        pull-based `get_log` buffer is the preferred way to consume bulk trace log.
+        """
+        return self._log_events_q.maxlen
+
+    @log_event_queue_maxlen.setter
+    def log_event_queue_maxlen(self, maxlen: int) -> None:
+        self._log_events_q = deque(self._log_events_q, maxlen=maxlen)
+
+    def _queue_for(self, event_type: EventType) -> deque:
+        if event_type == EventType.EVENT_LOG_MESSAGE:
+            return self._log_events_q
+        return self._debug_events_q
 
     def debug_event_publish(self, raw_event_data: list[any]):
         event = DbgEvent(raw_event_data[0], raw_event_data[1:])
-        while len(self._debug_events_q) > 100:
-            self._debug_events_q.pop(0)
-        self._debug_events_q.append(event)
+        # deque(maxlen=...) drops the oldest entry automatically once full.
+        self._queue_for(event.event_type).append(event)
         for listener in self.listeners.get(event.event_type, []):
             listener(event)
         return event
-    
+
     def get_latest_debug_event(self) -> DbgEvent | None:
         """
         Get the latest debug event that occurred in the debugee. The event is removed from the queue.
+
+        Note: `EVENT_LOG_MESSAGE` events are kept in a separate queue and are not
+        returned here. Retrieve them with `wait_for_debug_event(EventType.EVENT_LOG_MESSAGE)`,
+        a `watch_debug_event` callback, or the `get_log` buffer.
         """
         if len(self._debug_events_q) == 0:
             return None
         return self._debug_events_q.pop()
-    
+
     def peek_latest_debug_event(self) -> DbgEvent | None:
         """
         Get the latest debug event that occurred in the debugee. The event is not removed from the queue.
+
+        Note: `EVENT_LOG_MESSAGE` events are kept in a separate queue and are not returned here (see `get_latest_debug_event`).
         """
         if len(self._debug_events_q) == 0:
             return None
         return self._debug_events_q[-1]
-    
+
     def clear_debug_events(self, event_type: EventType | None = None) -> None:
         """
-        Clear the debug event queue. If `event_type` is specified, only events of that type will be removed.
-        
+        Clear buffered debug events. If `event_type` is specified, only events of that
+        type are removed (from whichever queue holds them); otherwise both the main
+        event queue and the `EVENT_LOG_MESSAGE` queue are cleared.
+
         Args:
             event_type: The type of event to clear. If None, all events will be cleared.
         """
-        filtered = []
-        for _ in range(len(self._debug_events_q)):
-            event = self._debug_events_q.pop(0)
-            if event.event_type != event_type and event_type is not None:
-                filtered.append(event)
-        self._debug_events_q = filtered
-    
+        if event_type is None:
+            self._debug_events_q.clear()
+            self._log_events_q.clear()
+            return
+        q = self._queue_for(event_type)
+        kept = [e for e in list(q) if e.event_type != event_type]
+        q.clear()
+        q.extend(kept)
+
     def wait_for_debug_event(self, event_type: EventType, timeout: int = 5) -> DbgEvent | None:
         """
         Wait for a debug event of a specific type to occur. This method returns the latest event of the specified type, which may have occurred before the method was called.
@@ -280,14 +350,20 @@ class DebugEventQueueMixin():
         Returns:
             DbgEvent | None: The latest event of the specified type, or None if the event did not occur within the timeout.
         """
+        q = self._queue_for(event_type)
         while timeout > 0:
-            for ix, event in enumerate(self._debug_events_q):
+            # Iterate a snapshot: the SUB thread may append/evict concurrently.
+            for event in list(q):
                 if event.event_type == event_type:
-                    return self._debug_events_q.pop(ix)
+                    try:
+                        q.remove(event)
+                    except ValueError:
+                        pass  # already evicted by the cap between snapshot and removal
+                    return event
             time.sleep(0.25)
             timeout -= 0.25
         return None
-    
+
     def watch_debug_event(self, event_type: EventType, callback: callable):
         """
         Register a callback to be invoked when a debug event of a specific type occurs.

--- a/x64dbg_automate/events.py
+++ b/x64dbg_automate/events.py
@@ -22,6 +22,7 @@ class EventType(StrEnum):
     EVENT_STOP_DEBUG = "EVENT_STOP_DEBUG"
     EVENT_CREATE_PROCESS = "EVENT_CREATE_PROCESS"
     EVENT_EXIT_PROCESS = "EVENT_EXIT_PROCESS"
+    EVENT_LOG_MESSAGE = "EVENT_LOG_MESSAGE"
 
 
 class BreakpointEventData(BaseModel):
@@ -106,9 +107,13 @@ class ExitProcessEventData(BaseModel):
     dwExitCode: int
 
 
+class LogMessageEventData(BaseModel):
+    message: str
+
+
 EventTypes = BreakpointEventData | SysBreakpointEventData | CreateThreadEventData | ExitThreadEventData | \
     LoadDllEventData | UnloadDllEventData | OutputDebugStringEventData | ExceptionEventData | AttachEventData | \
-    DetachEventData | InitDebugEventData | CreateProcessEventData | ExitProcessEventData | None
+    DetachEventData | InitDebugEventData | CreateProcessEventData | ExitProcessEventData | LogMessageEventData | None
 
 
 class DbgEvent():
@@ -198,6 +203,10 @@ class DbgEvent():
         elif event_type == EventType.EVENT_EXIT_PROCESS:
             self.event_data = ExitProcessEventData(
                 dwExitCode=event_data[0]
+            )
+        elif event_type == EventType.EVENT_LOG_MESSAGE:
+            self.event_data = LogMessageEventData(
+                message=event_data[0]
             )
         elif event_type == EventType.EVENT_EXCEPTION:
             self.event_data = ExceptionEventData(

--- a/x64dbg_automate/mcp_server.py
+++ b/x64dbg_automate/mcp_server.py
@@ -1156,24 +1156,40 @@ def refresh_gui() -> str:
 
 
 @mcp.tool()
-def get_log(since_index: int = 0) -> str:
+def get_log(since_index: int = 0, limit: int = 0, filter_str: str = "") -> str:
     """Retrieve x64dbg log output captured since a given index.
 
     The plugin buffers every line x64dbg writes to its log. Call with since_index=0
     to read everything currently buffered, then pass the returned "Next index" on
     the next call to fetch only newly-added lines (incremental polling). The buffer
-    is cleared when a new debug session starts.
+    and its index are reset when a new debug session starts, so a "Next index" from
+    a previous session restarts at the beginning of the new session's log (the
+    cursor is per-session).
+
+    For verbose logs, use `limit` and `filter_str` to bound the amount of text
+    returned: only lines containing `filter_str` are returned, and at most `limit`
+    entries per call (oldest first). When the result is truncated the response notes
+    how many matching entries remain; call again with the returned "Next index" to
+    continue.
 
     Args:
         since_index: Return only log lines at or after this index (0 for all buffered lines)
+        limit: Maximum number of matching entries to return (0 for no limit)
+        filter_str: Only return log lines containing this substring, case-sensitive and not a regex (empty for no filter)
     """
     try:
         client = _require_client()
-        next_index, lines = client.get_log(since_index)
+        next_index, lines, remaining, evicted = client.get_log(since_index, limit, filter_str)
+        notes = []
+        if remaining:
+            notes.append(f"{remaining} more matching entries remaining")
+        if evicted:
+            notes.append(f"{evicted} entries evicted before since_index")
+        suffix = f" ({'; '.join(notes)})" if notes else ""
         if not lines:
-            return f"No new log lines. Next index: {next_index}"
+            return f"No new log lines. Next index: {next_index}{suffix}"
         body = "\n".join(lines)
-        return f"{body}\n\nNext index: {next_index}"
+        return f"{body}\n\nNext index: {next_index}{suffix}"
     except Exception as e:
         return f"Error: {e}"
 

--- a/x64dbg_automate/mcp_server.py
+++ b/x64dbg_automate/mcp_server.py
@@ -1155,6 +1155,29 @@ def refresh_gui() -> str:
         return f"Error: {e}"
 
 
+@mcp.tool()
+def get_log(since_index: int = 0) -> str:
+    """Retrieve x64dbg log output captured since a given index.
+
+    The plugin buffers every line x64dbg writes to its log. Call with since_index=0
+    to read everything currently buffered, then pass the returned "Next index" on
+    the next call to fetch only newly-added lines (incremental polling). The buffer
+    is cleared when a new debug session starts.
+
+    Args:
+        since_index: Return only log lines at or after this index (0 for all buffered lines)
+    """
+    try:
+        client = _require_client()
+        next_index, lines = client.get_log(since_index)
+        if not lines:
+            return f"No new log lines. Next index: {next_index}"
+        body = "\n".join(lines)
+        return f"{body}\n\nNext index: {next_index}"
+    except Exception as e:
+        return f"Error: {e}"
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Companion client support for the plugin's log-capture hook in **dariushoule/x64dbg-automate#7**. Must ship together — this PR bumps `COMPAT_VERSION` to match the plugin's protocol bump, and the start-of-session handshake rejects mismatched plugin/client pairs.

## What's added
- **`get_log(since_index=0) -> (next_index, lines)`** — polls the plugin's bounded, monotonically-indexed log buffer. Pass the returned `next_index` to fetch only newly-added lines (incremental polling). The buffer is cleared at the start of each debug session.
- **`EVENT_LOG_MESSAGE` event type + `LogMessageEventData` model**, wired into `DbgEvent` dispatch so `watch_debug_event` / `wait_for_debug_event` work for log output.
- **`get_log` MCP tool** for incremental log retrieval from agents.
- **`COMPAT_VERSION` `lilac_bonnet` → `ghost_fungus`** to match the plugin.
- **Docs**: `get_log` + `LogMessageEventData` references in Debug Control; MCP tool table entry.

## Tests
- `tests/test_events.py` — pure-unit `EVENT_LOG_MESSAGE` parsing + dispatch (no live debugger). **Passing locally.**
- `tests/test_xauto_commands.py` — functional `get_log` incremental-retrieval and `EVENT_LOG_MESSAGE` delivery tests (require a live x64dbg + the PR #7 plugin build; not run in this environment).

## Merge order
Land alongside the plugin PR, then run the release e2e smoke test before publishing to PyPI.
