### PR TITLE
docs: forbid Claude/AI attribution in all GitHub text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ ZMQ REQ/REP for sync commands, PUB/SUB for async events. Msgpack serialization. 
 
 Keep all commits authored solely as the repo owner (Darius Houle) — do not add `Co-Authored-By` or other attribution trailers.
 
+Do not add Claude/AI attribution to any GitHub text on this project — commit messages, PR titles and descriptions, PR/issue comments, and issue bodies. This includes the `🤖 Generated with Claude Code` footer and any `Co-Authored-By: Claude` line. All such text must read as authored solely by the repo owner.
+
 ## Conventions
 - Type hints everywhere, modern union syntax (`X | None` not `Optional[X]`)
 - Pydantic models for data structures (`models.py`)


### PR DESCRIPTION
Broadens the existing commit-trailer rule in CLAUDE.md to cover all GitHub text authored on this project — commit messages, PR titles/descriptions, PR/issue comments, and issue bodies — explicitly including the `🤖 Generated with Claude Code` footer. Durable, in-repo preference so future Claude Code sessions don't add attribution.