### PR TITLE
Bump version to 0.9.0 for ghost_fungus release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "x64dbg_automate"
-version = "0.8.0"
+version = "0.9.0"
 description = "A Python library to automate x64dbg"
 authors = [{ name = "Darius Houle", email = "darius@x64.ooo" }]
 readme = "README.md"


### PR DESCRIPTION
Bumps the package version 0.8.0 -> 0.9.0 for the ghost_fungus release (0.8.0 is already published to PyPI). COMPAT_VERSION is already ghost_fungus on main.