### PR TITLE
fix: close connection after incompatible handshake

### DIFF
--- a/tests/test_connect_config.py
+++ b/tests/test_connect_config.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import subprocess
 from tests.conftest import TEST_BITNESS, X64DBG_PATH
 from x64dbg_automate import X64DbgClient
@@ -18,6 +19,23 @@ def test_reconnect(client: X64DbgClient):
 def test_compat_version(client: X64DbgClient):
     client.start_session()
     client._assert_connection_compat()
+
+
+def test_incompatible_version_closes_connection():
+    class Client:
+        closed = False
+
+        def _get_xauto_compat_version(self):
+            return "old_version"
+
+        def _close_connection(self):
+            self.closed = True
+
+    client = Client()
+    with pytest.raises(AssertionError, match="Incompatible x64dbg plugin and client versions"):
+        X64DbgClient._assert_connection_compat(client)
+
+    assert client.closed
 
 
 def test_bitness(client: X64DbgClient):

--- a/x64dbg_automate/__init__.py
+++ b/x64dbg_automate/__init__.py
@@ -170,7 +170,9 @@ class X64DbgClient(XAutoHighLevelCommandAbstractionMixin, DebugEventQueueMixin):
 
     def _assert_connection_compat(self) -> None:
         v = self._get_xauto_compat_version()
-        assert v == COMPAT_VERSION, f"Incompatible x64dbg plugin and client versions {v} != {COMPAT_VERSION}"
+        if v != COMPAT_VERSION:
+            self._close_connection()
+            raise AssertionError(f"Incompatible x64dbg plugin and client versions {v} != {COMPAT_VERSION}")
         
     def _launch_x64dbg(self) -> int:
         if self.x64dbg_path is None:


### PR DESCRIPTION
Closes #20

## Summary

- close the ZMQ connection when the compatibility handshake rejects a plugin version
- let existing teardown stop and join the SUB event thread before re-raising
- add a regression test for the cleanup path

## Testing

- `pytest -q tests/test_events.py tests/test_mcp_server.py tests/test_connect_config.py::test_incompatible_version_closes_connection` (108 passed)
- `python -m compileall -q x64dbg_automate tests/test_connect_config.py`

Not run: the Windows/x64dbg functional suite, which requires a running debugger and plugin.