### PR TITLE
Add read_memory output formats, raise the cap, batch scattered reads

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -84,7 +84,7 @@ The MCP server provides ~40 tools organized into the following groups:
 |-------|-------|-------------|
 | Session | `list_sessions`, `start_session`, `connect_to_session`, `connect_remote`, `disconnect`, `terminate_session` | Manage debugger instances |
 | Debug Control | `go`, `pause`, `step_into`, `step_over`, `skip_instruction`, `run_to_return`, `get_debugger_status` | Control execution |
-| Memory | `read_memory`, `write_memory`, `allocate_memory`, `free_memory`, `get_memory_map` | Read/write debuggee memory |
+| Memory | `read_memory`, `read_memory_many`, `write_memory`, `allocate_memory`, `free_memory`, `get_memory_map` | Read/write debuggee memory |
 | Registers | `get_register`, `set_register`, `get_all_registers` | Register access |
 | Expressions | `eval_expression`, `execute_command` | x64dbg expression evaluator and raw commands |
 | Breakpoints | `set_breakpoint`, `clear_breakpoint`, `toggle_breakpoint`, `list_breakpoints` | Software, hardware, and memory breakpoints |
@@ -186,6 +186,8 @@ Claude will call `disconnect`, leaving x64dbg running for manual inspection, or 
 
 - **Let Claude drive**: Describe your analysis goal in plain language. Claude can chain multiple tools together to investigate, set breakpoints, read memory, and modify state.
 - **Expressions work everywhere**: Any tool that takes an address also accepts registers, symbols, and arithmetic expressions — just like the x64dbg command bar.
-- **Memory reads are capped**: `read_memory` is limited to 4096 bytes per call and `disassemble` to 100 instructions. Ask for multiple reads if you need more.
+- **Memory reads are capped**: `read_memory` is limited to 1 MiB per call and `disassemble` to 100 instructions. Ask for multiple reads if you need more.
+- **Compact output for bulk reads**: `read_memory` defaults to a hex dump with an ASCII sidebar, which costs roughly 3x the raw bytes. Pass `format='hex'` or `format='base64'` when reading structures repeatedly.
+- **Batch scattered reads**: When walking linked structures, `read_memory_many(['esi+0x10:4', '0x1000:16'])` fetches several ranges in one call. A read that fails is reported inline, so a partially-mapped structure still yields its readable fields.
 - **Events for synchronization**: Use `wait_for_event` to wait for breakpoints, DLL loads, or other debug events before inspecting state.
 - **Raw commands**: If a feature isn't exposed as a dedicated tool, `execute_command` passes any command directly to x64dbg's command interpreter. See the [x64dbg command reference](https://help.x64dbg.com/en/latest/commands/).

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -492,8 +492,50 @@ class TestReadMemory:
 
     def test_size_capped(self, mock_client):
         mock_client.read_memory.return_value = b"\x00"
+        mcp_mod.read_memory("0x1000", 99_999_999)
+        mock_client.read_memory.assert_called_once_with(0x1000, mcp_mod.MAX_READ_BYTES)
+
+    def test_size_below_cap_passed_through(self, mock_client):
+        mock_client.read_memory.return_value = b"\x00" * 9999
         mcp_mod.read_memory("0x1000", 9999)
-        mock_client.read_memory.assert_called_once_with(0x1000, 4096)
+        mock_client.read_memory.assert_called_once_with(0x1000, 9999)
+
+    def test_format_hex(self, mock_client):
+        mock_client.read_memory.return_value = b"\xde\xad\xbe\xef"
+        assert mcp_mod.read_memory("0x1000", 4, format="hex") == "DEADBEEF"
+
+    def test_format_base64(self, mock_client):
+        mock_client.read_memory.return_value = b"\xde\xad\xbe\xef"
+        assert mcp_mod.read_memory("0x1000", 4, format="base64") == "3q2+7w=="
+
+    def test_format_dump_is_default(self, mock_client):
+        mock_client.read_memory.return_value = b"\xde\xad\xbe\xef"
+        assert mcp_mod.read_memory("0x1000", 4) == mcp_mod.read_memory("0x1000", 4, format="dump")
+
+    def test_invalid_format(self, mock_client):
+        mock_client.read_memory.return_value = b"\x00"
+        assert "Error" in mcp_mod.read_memory("0x1000", 1, format="yaml")
+
+
+class TestReadMemoryMany:
+    def test_batch(self, mock_client):
+        mock_client.read_memory.side_effect = [b"\xaa\xbb", b"\xcc"]
+        result = mcp_mod.read_memory_many(["0x1000:2", "0x2000:1"])
+        assert "0x1000:2 @0x1000 = AABB" in result
+        assert "0x2000:1 @0x2000 = CC" in result
+
+    def test_one_failure_does_not_abort_others(self, mock_client):
+        mock_client.read_memory.side_effect = [RuntimeError("XERROR_READ_FAILED"), b"\xcc"]
+        result = mcp_mod.read_memory_many(["0x1000:2", "0x2000:1"])
+        assert "0x1000:2 ERROR: XERROR_READ_FAILED" in result
+        assert "0x2000:1 @0x2000 = CC" in result
+
+    def test_malformed_spec(self, mock_client):
+        result = mcp_mod.read_memory_many(["garbage"])
+        assert "ERROR" in result
+
+    def test_empty(self, mock_client):
+        assert "No reads requested" in mcp_mod.read_memory_many([])
 
 
 class TestWriteMemory:

--- a/x64dbg_automate/mcp_server.py
+++ b/x64dbg_automate/mcp_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import os
 import struct
 import sys
@@ -26,7 +27,9 @@ mcp = FastMCP(
     instructions=(
         "MCP server for controlling the x64dbg debugger via x64dbg-automate. "
         "Use list_sessions or start_session first, then connect before using other tools. "
-        "Addresses are hex strings (e.g. '0x7FF6A0001000'). Memory reads return hex dumps."
+        "Addresses are hex strings (e.g. '0x7FF6A0001000'). Memory reads return hex dumps "
+        "by default; pass format='hex' or 'base64' for compact output, and use "
+        "read_memory_many to batch scattered struct-field reads."
     ),
 )
 
@@ -80,6 +83,22 @@ def _format_memory(data: bytes, base: int) -> str:
         ascii_part = "".join(chr(b) if 0x20 <= b < 0x7F else "." for b in chunk)
         lines.append(f"{_format_address(base + offset)}  {hex_part:<48s}  {ascii_part}")
     return "\n".join(lines)
+
+
+# Only the MCP layer caps reads: the plugin issues an unbounded DbgMemRead and the
+# transport is msgpack bytes, so this is purely a response-size guard.
+MAX_READ_BYTES = 1024 * 1024
+
+
+def _encode_memory(data: bytes, addr: int, format: str) -> str:
+    """Render read bytes in the requested output format."""
+    if format == "dump":
+        return _format_memory(data, addr)
+    if format == "hex":
+        return data.hex().upper()
+    if format == "base64":
+        return base64.b64encode(data).decode("ascii")
+    raise ValueError(f"Invalid format '{format}': expected 'dump', 'hex', or 'base64'")
 
 
 def _pe_bitness(exe_path: str) -> int:
@@ -495,21 +514,63 @@ def trace_over(
 # ---------------------------------------------------------------------------
 
 @mcp.tool()
-def read_memory(address: str, size: int = 256) -> str:
-    """Read memory from the debuggee. Returns hex dump with ASCII sidebar.
+def read_memory(address: str, size: int = 256, format: str = "dump") -> str:
+    """Read memory from the debuggee.
 
     Args:
         address: Address — hex ('0x7FF6A0001000'), register ('RSP'), symbol, or expression ('rsp+0x20')
-        size: Number of bytes to read (max 4096)
+        size: Number of bytes to read (max 1048576)
+        format: Output encoding:
+            'dump'   — hex dump with ASCII sidebar (default; human-readable, ~3x the raw bytes)
+            'hex'    — contiguous uppercase hex, no separators
+            'base64' — base64, most compact for bulk reads
     """
     try:
         client = _require_client()
         addr = _parse_address_or_expression(address)
-        size = min(size, 4096)
+        size = max(0, min(size, MAX_READ_BYTES))
         data = client.read_memory(addr, size)
-        return _format_memory(data, addr)
+        return _encode_memory(data, addr, format)
     except Exception as e:
         return f"Error: {e}"
+
+
+@mcp.tool()
+def read_memory_many(reads: list[str], format: str = "hex") -> str:
+    """Read several memory ranges in one call — for walking scattered struct fields.
+
+    Each read is resolved and reported independently: one failing address does not
+    abort the others, so a partially-mapped structure still yields its readable fields.
+
+    Args:
+        reads: Ranges as '<address>:<size>' strings, e.g. ['0x1000:16', 'esi+0x10:4'].
+               The address accepts the same forms as read_memory.
+        format: Output encoding per read — 'hex' (default), 'base64', or 'dump'.
+
+    Returns:
+        One line per read: '<spec> @<resolved address> = <encoded bytes>', or
+        '<spec> ERROR: <reason>' for reads that could not be satisfied.
+    """
+    try:
+        client = _require_client()
+    except Exception as e:
+        return f"Error: {e}"
+
+    lines = []
+    for spec in reads:
+        try:
+            addr_part, _, size_part = spec.rpartition(":")
+            if not addr_part:
+                raise ValueError("expected '<address>:<size>'")
+            addr = _parse_address_or_expression(addr_part)
+            size = max(0, min(int(size_part, 0), MAX_READ_BYTES))
+            data = client.read_memory(addr, size)
+            encoded = _encode_memory(data, addr, format)
+            separator = "\n" if format == "dump" else " "
+            lines.append(f"{spec} @{_format_address(addr)} ={separator}{encoded}")
+        except Exception as e:
+            lines.append(f"{spec} ERROR: {e}")
+    return "\n".join(lines) if lines else "No reads requested."
 
 
 @mcp.tool()


### PR DESCRIPTION
First of three related MCP memory-tool changes. **Independent — merge in any order.**

### Output formats

`read_memory` only emitted a hex dump with an ASCII sidebar, roughly 3x the size of the raw bytes. That is a real cost when an agent reads the same structures repeatedly across a session.

Adds `format="dump"|"hex"|"base64"`. **`dump` remains the default, so existing behaviour is unchanged.** Measured against a live 64-byte read: `hex` is 0.42x and `base64` 0.29x the size of `dump`.

### Cap raised 4KiB → 1MiB

The 4096-byte cap was purely a client-side choice. The plugin issues an unbounded `DbgMemRead` and the transport is msgpack `bytes`, so nothing below the MCP layer was enforcing it. The new constant is a response-size guard rather than a protocol limit; verified end to end with a 16,384-byte read.

### `read_memory_many`

Batches several ranges into one call, for walking linked structures where scattered small field reads are the dominant access pattern:

```
read_memory_many(["esi+0x10:4", "0x1000:16"])
```

Each read resolves independently and failures are reported inline, so a partially-mapped structure still yields its readable fields rather than losing the whole batch.

### Testing

11 new unit tests (mocked, no debugger required). Also exercised against a live remote 32-bit session: format round-tripping, the raised cap, and batch partial-failure against a real `XERROR_READ_FAILED`.