### PR TITLE
Tighten no-debuggee probing and drop an unused constant

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -481,11 +481,38 @@ class TestNoDebuggeeDisambiguation:
         mcp_mod.read_memory("0x10000", 4)
         mock_client.is_debugging.assert_not_called()
 
-    def test_read_many_refuses_without_debuggee(self, mock_client):
+    def test_read_many_failure_names_no_debuggee(self, mock_client):
         mock_client.is_debugging.return_value = False
+        mock_client.read_memory.side_effect = RuntimeError("XERROR_READ_FAILED")
         result = mcp_mod.read_memory_many(["0x1000:4"])
+        assert "XERROR_READ_FAILED" in result
         assert "No debuggee" in result
-        mock_client.read_memory.assert_not_called()
+
+    def test_read_many_hint_is_appended_once_for_many_failures(self, mock_client):
+        mock_client.is_debugging.return_value = False
+        mock_client.read_memory.side_effect = RuntimeError("XERROR_READ_FAILED")
+        result = mcp_mod.read_memory_many(["0x1000:4", "0x2000:4", "0x3000:4"])
+        assert result.count("No debuggee") == 1
+        mock_client.is_debugging.assert_called_once()
+
+    def test_successful_batch_costs_no_extra_roundtrip(self, mock_client):
+        mock_client.read_memory.return_value = b"\x90" * 4
+        mcp_mod.read_memory_many(["0x1000:4", "0x2000:4"])
+        mock_client.is_debugging.assert_not_called()
+
+    def test_read_many_failure_with_debuggee_is_bad_address(self, mock_client):
+        mock_client.is_debugging.return_value = True
+        mock_client.read_memory.side_effect = RuntimeError("XERROR_READ_FAILED")
+        result = mcp_mod.read_memory_many(["0x1:4"])
+        assert "XERROR_READ_FAILED" in result
+        assert "No debuggee" not in result
+
+    def test_memmap_reports_absence_before_complaining_about_filters(self, mock_client):
+        # A detached session must say so rather than rejecting the filter arguments.
+        mock_client.is_debugging.return_value = False
+        result = mcp_mod.get_memory_map(state="bogus")
+        assert "No debuggee" in result
+        mock_client.memmap.assert_not_called()
 
 
 class TestGo:

--- a/x64dbg_automate/mcp_server.py
+++ b/x64dbg_automate/mcp_server.py
@@ -655,10 +655,11 @@ def read_memory_many(reads: list[str], format: str = "hex") -> str:
     except Exception as e:
         return f"Error: {e}"
 
-    if not client.is_debugging():
-        return NO_DEBUGGEE_MSG
+    if not reads:
+        return "No reads requested."
 
     lines = []
+    failed = False
     for spec in reads:
         try:
             addr_part, _, size_part = spec.rpartition(":")
@@ -671,8 +672,13 @@ def read_memory_many(reads: list[str], format: str = "hex") -> str:
             separator = "\n" if format == "dump" else " "
             lines.append(f"{spec} @{_format_address(addr)} ={separator}{encoded}")
         except Exception as e:
+            failed = True
             lines.append(f"{spec} ERROR: {e}")
-    return "\n".join(lines) if lines else "No reads requested."
+
+    # Probe for a debuggee once, and only if something failed, so a fully
+    # successful batch costs no extra round trip — same rule as read_memory.
+    suffix = _no_debuggee_hint(client).lstrip(" —") if failed else ""
+    return "\n".join(lines) + (f"\n{suffix}" if suffix else "")
 
 
 @mcp.tool()
@@ -760,14 +766,17 @@ def get_memory_map(
     """
     try:
         client = _require_client()
-        want_state = _named_filter_value(state, _STATE_NAMES, "state")
-        want_type = _named_filter_value(mem_type, _TYPE_NAMES, "mem_type")
 
         # DbgMemMap copies x64dbg's memoryPages cache with no debuggee check, and that
         # cache is only refreshed on debug events. With nothing attached it returns the
         # dead process's map, which looks like a successful result. Fail loudly instead.
+        # Checked before the filters are parsed so a detached session reports the
+        # absence rather than a complaint about the filter arguments.
         if not client.is_debugging():
             return NO_DEBUGGEE_MSG
+
+        want_state = _named_filter_value(state, _STATE_NAMES, "state")
+        want_type = _named_filter_value(mem_type, _TYPE_NAMES, "mem_type")
 
         pages = client.memmap()
         total = len(pages)

--- a/x64dbg_automate/models.py
+++ b/x64dbg_automate/models.py
@@ -23,11 +23,6 @@ PAGE_EXECUTE_READWRITE = 0x40
 PAGE_EXECUTE_WRITECOPY = 0x80
 PAGE_GUARD = 0x100
 
-# Copy-on-write pages count as writable.
-WRITABLE_PROTECTIONS = frozenset({
-    PAGE_READWRITE, PAGE_WRITECOPY, PAGE_EXECUTE_READWRITE, PAGE_EXECUTE_WRITECOPY,
-})
-
 
 class DebugSession(BaseModel):
     """


### PR DESCRIPTION
Follow-ups to the memory-tool stack (#23, #24, #25), from reviewing them against a live debugger.

### `read_memory_many` probed for a debuggee on every call

#24 established the rule that a successful read costs no extra round trip — `read_memory` checks `is_debugging()` only on the error path, with a test asserting it is never called on success. `read_memory_many` did not follow it: it probed unconditionally up front and refused the whole batch.

It now probes only when a read actually failed, and appends the hint once for the batch rather than refusing outright — so a partially-mapped structure still yields its readable fields, which is the tool's stated purpose.

`get_memory_map` keeps its unconditional check; that one is necessary, because the stale cache comes back as a *success* and there is no error path to hang the check on.

### `get_memory_map` complained about filters when there was no debuggee

Filter arguments were parsed before the debuggee check, so a detached session reported an invalid-filter error instead of the absence. Check first.

### `WRITABLE_PROTECTIONS` was never referenced

`_protect_matches` decides writability from the decoded triplet, so the constant in `models.py` was dead on arrival. Removed.

### Testing

148 mocked tests pass. `test_read_many_refuses_without_debuggee` encoded the old refuse-outright behaviour and is replaced by four tests covering the new contract: the hint appears on failure, appears exactly once across several failures, is absent when a debuggee is present, and is not probed at all when the batch fully succeeds. Plus one asserting `get_memory_map` reports absence ahead of filter validation.

The three PRs themselves were verified live against real x64dbg and x32dbg sessions before these fixes; the x32 functional suite passes with them.