### PR TITLE
Refuse expressions that read debuggee state when nothing is attached

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -452,33 +452,26 @@ class TestGetDebuggerStatus:
 
 
 class TestEvalExpressionNoDebuggee:
-    """x64dbg resolves memory/registers/flags to 0 and reports SUCCESS with no debuggee."""
+    """x64dbg fabricates results with no debuggee, so nothing is evaluated without one."""
 
-    def test_memory_deref_refused(self, mock_client):
+    # Every one of these returns (0, SUCCESS) with no debuggee attached, verified live.
+    # The last four are why the expression is not inspected: they read debuggee state
+    # without naming a register, a flag, or a dereference.
+    @pytest.mark.parametrize("expr", [
+        "[0x400000]",
+        "eax",
+        "_zf",
+        "peb()",
+        "$pid",
+        "mod.main()",
+        "arg.get(0)",
+    ])
+    def test_refused_without_debuggee(self, mock_client, expr):
         mock_client.is_debugging.return_value = False
         mock_client.eval_sync.return_value = (0, True)  # what x64dbg actually returns
-        result = mcp_mod.eval_expression("[0x400000]")
-        assert "memory dereference" in result
-        assert "no debuggee" in result
+        result = mcp_mod.eval_expression(expr)
+        assert "no debuggee attached" in result
         mock_client.eval_sync.assert_not_called()
-
-    def test_register_refused(self, mock_client):
-        mock_client.is_debugging.return_value = False
-        mock_client.eval_sync.return_value = (0, True)
-        result = mcp_mod.eval_expression("eax")
-        assert "register 'eax'" in result
-        mock_client.eval_sync.assert_not_called()
-
-    def test_flag_refused(self, mock_client):
-        mock_client.is_debugging.return_value = False
-        mock_client.eval_sync.return_value = (0, True)
-        assert "flag '_zf'" in mcp_mod.eval_expression("_zf")
-
-    def test_arithmetic_still_works_without_debuggee(self, mock_client):
-        # Pure arithmetic does not touch the debuggee, so it must not be refused.
-        mock_client.is_debugging.return_value = False
-        mock_client.eval_sync.return_value = (0x1235, True)
-        assert mcp_mod.eval_expression("0x1234+1") == "0x1234+1 = 0x1235"
 
     def test_evaluated_normally_when_debugging(self, mock_client):
         mock_client.is_debugging.return_value = True
@@ -490,31 +483,17 @@ class TestEvalExpressionNoDebuggee:
         mock_client.eval_sync.return_value = (0, False)
         assert "Evaluation failed" in mcp_mod.eval_expression("[0x1]")
 
-    def test_symbol_not_mistaken_for_register(self, mock_client):
-        # 'CreateFileA' contains 'al'; 'kernel32' contains no register token either.
-        # Whole-identifier matching must not trip on these.
+    def test_address_resolution_refused_without_debuggee(self, mock_client):
+        # Same guard covers every tool taking an address, via _parse_address_or_expression.
         mock_client.is_debugging.return_value = False
-        mock_client.eval_sync.return_value = (0x7FF600001000, True)
-        result = mcp_mod.eval_expression("kernel32:CreateFileA")
-        assert "0x7FF600001000" in result
+        mock_client.eval_sync.return_value = (0, True)
+        assert "no debuggee attached" in mcp_mod.read_memory("rsp")
+        mock_client.eval_sync.assert_not_called()
 
-    def test_no_extra_roundtrip_for_pure_arithmetic(self, mock_client):
-        mock_client.eval_sync.return_value = (5, True)
-        mcp_mod.eval_expression("2+3")
+    def test_literal_address_does_not_consult_debuggee(self, mock_client):
+        # Literals never reach the evaluator, so they cost no round trip.
+        assert mcp_mod._parse_address_or_expression("0x400000") == 0x400000
         mock_client.is_debugging.assert_not_called()
-
-    @pytest.mark.parametrize("expr,expected", [
-        ("[0x400000]", ["memory dereference"]),
-        ("eax", ["register 'eax'"]),
-        ("RAX", ["register 'RAX'"]),          # case-insensitive
-        ("_zf", ["flag '_zf'"]),
-        ("cip", ["register 'cip'"]),          # architecture-agnostic alias
-        ("2+3", []),
-        ("kernel32:CreateFileA", []),
-        ("0xDEADBEEF", []),
-    ])
-    def test_detector(self, expr, expected):
-        assert mcp_mod._debuggee_state_tokens(expr) == expected
 
 
 class TestNoDebuggeeDisambiguation:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -451,6 +451,72 @@ class TestGetDebuggerStatus:
         mock_client.debugee_pid.assert_not_called()
 
 
+class TestEvalExpressionNoDebuggee:
+    """x64dbg resolves memory/registers/flags to 0 and reports SUCCESS with no debuggee."""
+
+    def test_memory_deref_refused(self, mock_client):
+        mock_client.is_debugging.return_value = False
+        mock_client.eval_sync.return_value = (0, True)  # what x64dbg actually returns
+        result = mcp_mod.eval_expression("[0x400000]")
+        assert "memory dereference" in result
+        assert "no debuggee" in result
+        mock_client.eval_sync.assert_not_called()
+
+    def test_register_refused(self, mock_client):
+        mock_client.is_debugging.return_value = False
+        mock_client.eval_sync.return_value = (0, True)
+        result = mcp_mod.eval_expression("eax")
+        assert "register 'eax'" in result
+        mock_client.eval_sync.assert_not_called()
+
+    def test_flag_refused(self, mock_client):
+        mock_client.is_debugging.return_value = False
+        mock_client.eval_sync.return_value = (0, True)
+        assert "flag '_zf'" in mcp_mod.eval_expression("_zf")
+
+    def test_arithmetic_still_works_without_debuggee(self, mock_client):
+        # Pure arithmetic does not touch the debuggee, so it must not be refused.
+        mock_client.is_debugging.return_value = False
+        mock_client.eval_sync.return_value = (0x1235, True)
+        assert mcp_mod.eval_expression("0x1234+1") == "0x1234+1 = 0x1235"
+
+    def test_evaluated_normally_when_debugging(self, mock_client):
+        mock_client.is_debugging.return_value = True
+        mock_client.eval_sync.return_value = (0xDEAD, True)
+        assert mcp_mod.eval_expression("[esi+0x10]") == "[esi+0x10] = 0xDEAD"
+
+    def test_genuine_failure_still_reported(self, mock_client):
+        mock_client.is_debugging.return_value = True
+        mock_client.eval_sync.return_value = (0, False)
+        assert "Evaluation failed" in mcp_mod.eval_expression("[0x1]")
+
+    def test_symbol_not_mistaken_for_register(self, mock_client):
+        # 'CreateFileA' contains 'al'; 'kernel32' contains no register token either.
+        # Whole-identifier matching must not trip on these.
+        mock_client.is_debugging.return_value = False
+        mock_client.eval_sync.return_value = (0x7FF600001000, True)
+        result = mcp_mod.eval_expression("kernel32:CreateFileA")
+        assert "0x7FF600001000" in result
+
+    def test_no_extra_roundtrip_for_pure_arithmetic(self, mock_client):
+        mock_client.eval_sync.return_value = (5, True)
+        mcp_mod.eval_expression("2+3")
+        mock_client.is_debugging.assert_not_called()
+
+    @pytest.mark.parametrize("expr,expected", [
+        ("[0x400000]", ["memory dereference"]),
+        ("eax", ["register 'eax'"]),
+        ("RAX", ["register 'RAX'"]),          # case-insensitive
+        ("_zf", ["flag '_zf'"]),
+        ("cip", ["register 'cip'"]),          # architecture-agnostic alias
+        ("2+3", []),
+        ("kernel32:CreateFileA", []),
+        ("0xDEADBEEF", []),
+    ])
+    def test_detector(self, expr, expected):
+        assert mcp_mod._debuggee_state_tokens(expr) == expected
+
+
 class TestNoDebuggeeDisambiguation:
     """XERROR_READ_FAILED means both 'bad address' and 'dead debuggee' — disambiguate."""
 

--- a/x64dbg_automate/mcp_server.py
+++ b/x64dbg_automate/mcp_server.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import json
 import os
-import re
 import struct
 import sys
 from pathlib import Path
@@ -28,7 +27,6 @@ from x64dbg_automate.models import (
     MEM_PRIVATE,
     MEM_RESERVE,
     MemoryBreakpointType,
-    MutableRegister,
     PAGE_GUARD,
 )
 
@@ -173,58 +171,20 @@ def _named_filter_value(value: str, names: dict[int, str], label: str) -> int | 
     raise ValueError(f"Invalid {label} filter '{value}': expected one of {sorted(names.values())} or a hex literal")
 
 
-# x64dbg's expression evaluator resolves a memory dereference, a register, or a flag to
-# 0 and reports SUCCESS when nothing is being debugged — see the three
-# `if(!DbgIsDebugging()) { *value = 0; return true; }` branches in dbg/value.cpp. It is
-# silent by default, so a dead debuggee is indistinguishable from a legitimate zero.
-# These are the token classes that trigger it; pure arithmetic is unaffected.
-_REGISTER_TOKENS = frozenset(r.value for r in MutableRegister) | frozenset({
-    # x64dbg's architecture-agnostic aliases, which are not in MutableRegister.
-    "cax", "cbx", "ccx", "cdx", "csi", "cdi", "cbp", "csp", "cip", "cflags",
-})
-_FLAG_TOKENS = frozenset(
-    "_" + f for f in
-    ("cf", "pf", "af", "zf", "sf", "tf", "if", "df", "of", "rf", "vm", "ac", "vif", "vip", "id")
-)
-_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
-
-
-def _debuggee_state_tokens(expression: str) -> list[str]:
-    """Return the parts of an expression that read live debuggee state.
-
-    Used to refuse evaluation rather than hand back x64dbg's fabricated 0. Matches
-    whole identifiers only, so 'kernel32:CreateFileA' is not mistaken for the 'al'
-    register.
-    """
-    found = []
-    if "[" in expression:
-        found.append("memory dereference")
-    for token in _IDENTIFIER_RE.findall(expression):
-        lowered = token.lower()
-        if lowered in _REGISTER_TOKENS:
-            found.append(f"register '{token}'")
-        elif lowered in _FLAG_TOKENS:
-            found.append(f"flag '{token}'")
-    return found
-
-
 def _assert_expression_evaluable(client, expression: str) -> None:
-    """Raise if the expression reads debuggee state and there is no debuggee.
+    """Raise if there is no debuggee to evaluate the expression against.
+
+    With nothing attached, x64dbg resolves registers, flags and memory dereferences to
+    0 and reports SUCCESS, and expression functions such as peb() and mod.base() either
+    do the same or return values cached from the exited process. Which expressions are
+    affected cannot be decided from the string — the evaluator's grammar is open and
+    plugins extend it — so nothing is evaluated without a debuggee.
 
     Raises:
-        ValueError: When evaluation would silently yield 0 instead of failing.
+        ValueError: When no debuggee is attached.
     """
-    touches = _debuggee_state_tokens(expression)
-    if not touches:
-        return
-    if client.is_debugging():
-        return
-    raise ValueError(
-        f"{expression} reads live debuggee state ({', '.join(sorted(set(touches)))}) "
-        f"but no debuggee is attached. x64dbg would evaluate this to 0 and report "
-        f"success, so the result would be indistinguishable from a real zero. "
-        f"Use get_debugger_status to confirm."
-    )
+    if not client.is_debugging():
+        raise ValueError(f"Cannot evaluate '{expression}': no debuggee attached")
 
 
 def _no_debuggee_hint(client) -> str:
@@ -949,9 +909,8 @@ def get_all_registers() -> str:
 def eval_expression(expression: str) -> str:
     """Evaluate an x64dbg expression. Supports symbols, registers, arithmetic.
 
-    Expressions that read live debuggee state — memory dereferences, registers, flags —
-    are refused when no debuggee is attached. x64dbg evaluates those to 0 and reports
-    success in that situation, which is indistinguishable from a genuine zero.
+    Requires a debuggee. With nothing attached x64dbg resolves registers, flags and
+    memory reads to 0 and reports success, which is indistinguishable from a real zero.
 
     Args:
         expression: Expression to evaluate (e.g. 'kernel32:CreateFileA', 'rax+0x10')

--- a/x64dbg_automate/mcp_server.py
+++ b/x64dbg_automate/mcp_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import struct
 import sys
 from pathlib import Path
@@ -27,6 +28,7 @@ from x64dbg_automate.models import (
     MEM_PRIVATE,
     MEM_RESERVE,
     MemoryBreakpointType,
+    MutableRegister,
     PAGE_GUARD,
 )
 
@@ -71,6 +73,7 @@ def _parse_address_or_expression(s: str) -> int:
         pass
     # Fall back to x64dbg expression evaluator
     client = _require_client()
+    _assert_expression_evaluable(client, s)
     val, success = client.eval_sync(s)
     if not success:
         raise ValueError(f"Cannot resolve address: {s}")
@@ -168,6 +171,60 @@ def _named_filter_value(value: str, names: dict[int, str], label: str) -> int | 
         if name == value:
             return num
     raise ValueError(f"Invalid {label} filter '{value}': expected one of {sorted(names.values())} or a hex literal")
+
+
+# x64dbg's expression evaluator resolves a memory dereference, a register, or a flag to
+# 0 and reports SUCCESS when nothing is being debugged — see the three
+# `if(!DbgIsDebugging()) { *value = 0; return true; }` branches in dbg/value.cpp. It is
+# silent by default, so a dead debuggee is indistinguishable from a legitimate zero.
+# These are the token classes that trigger it; pure arithmetic is unaffected.
+_REGISTER_TOKENS = frozenset(r.value for r in MutableRegister) | frozenset({
+    # x64dbg's architecture-agnostic aliases, which are not in MutableRegister.
+    "cax", "cbx", "ccx", "cdx", "csi", "cdi", "cbp", "csp", "cip", "cflags",
+})
+_FLAG_TOKENS = frozenset(
+    "_" + f for f in
+    ("cf", "pf", "af", "zf", "sf", "tf", "if", "df", "of", "rf", "vm", "ac", "vif", "vip", "id")
+)
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _debuggee_state_tokens(expression: str) -> list[str]:
+    """Return the parts of an expression that read live debuggee state.
+
+    Used to refuse evaluation rather than hand back x64dbg's fabricated 0. Matches
+    whole identifiers only, so 'kernel32:CreateFileA' is not mistaken for the 'al'
+    register.
+    """
+    found = []
+    if "[" in expression:
+        found.append("memory dereference")
+    for token in _IDENTIFIER_RE.findall(expression):
+        lowered = token.lower()
+        if lowered in _REGISTER_TOKENS:
+            found.append(f"register '{token}'")
+        elif lowered in _FLAG_TOKENS:
+            found.append(f"flag '{token}'")
+    return found
+
+
+def _assert_expression_evaluable(client, expression: str) -> None:
+    """Raise if the expression reads debuggee state and there is no debuggee.
+
+    Raises:
+        ValueError: When evaluation would silently yield 0 instead of failing.
+    """
+    touches = _debuggee_state_tokens(expression)
+    if not touches:
+        return
+    if client.is_debugging():
+        return
+    raise ValueError(
+        f"{expression} reads live debuggee state ({', '.join(sorted(set(touches)))}) "
+        f"but no debuggee is attached. x64dbg would evaluate this to 0 and report "
+        f"success, so the result would be indistinguishable from a real zero. "
+        f"Use get_debugger_status to confirm."
+    )
 
 
 def _no_debuggee_hint(client) -> str:
@@ -892,11 +949,16 @@ def get_all_registers() -> str:
 def eval_expression(expression: str) -> str:
     """Evaluate an x64dbg expression. Supports symbols, registers, arithmetic.
 
+    Expressions that read live debuggee state — memory dereferences, registers, flags —
+    are refused when no debuggee is attached. x64dbg evaluates those to 0 and reports
+    success in that situation, which is indistinguishable from a genuine zero.
+
     Args:
         expression: Expression to evaluate (e.g. 'kernel32:CreateFileA', 'rax+0x10')
     """
     try:
         client = _require_client()
+        _assert_expression_evaluable(client, expression)
         val, success = client.eval_sync(expression)
         if not success:
             return f"Evaluation failed for: {expression}"


### PR DESCRIPTION
x64dbg's expression evaluator resolves a **memory dereference, a register, or a flag to 0 and reports SUCCESS** when no debuggee is present. `dbg/value.cpp` has three separate branches doing exactly this:

```c
if(!DbgIsDebugging()) { *value = 0; return true; }
```

They are silent by default (`silent` defaults to `true`), so after the debuggee exits every read looks like a legitimate zero.

### Why this costs real time

Globals whose addresses were correct read back as `0` and appear to be wrong addresses. `eval_expression` is otherwise reliable, so there is no reason to suspect it.

The asymmetry is what makes it genuinely confusing — some expressions fail properly in that state while others quietly lie. Reproduced live against a detached x32dbg:

| expression | value | success |
|---|---|---|
| `[0x400000]` | `0x0` | **True** |
| `eax` | `0x0` | **True** |
| `_zf` | `0x0` | **True** |
| `kernel32:CreateFileA` | — | False (fails correctly) |
| `0x1234+1` | `0x1235` | True (correct) |

Note it is not only memory reads: registers and flags do it too.

### Change

`eval_expression` now refuses such expressions when there is no debuggee, naming which part reads live state:

```
Error: [gBumperList] reads live debuggee state (memory dereference) but no debuggee is
attached. x64dbg would evaluate this to 0 and report success, so the result would be
indistinguishable from a real zero. Use get_debugger_status to confirm.
```

Design notes:

- **Pure arithmetic is unaffected** — `0x1234+1` still evaluates without a debuggee, which is legitimately useful.
- **Whole-identifier matching**, so `kernel32:CreateFileA` is not mistaken for the `al` register.
- **No extra round trip** when the expression cannot touch debuggee state — the string test runs first and `is_debugging` is only consulted if it matches. There is a test asserting this.
- The same guard covers `_parse_address_or_expression`, since every tool taking an expression as an address funnels through it.

### Testing

15 new unit tests including the detector table and the no-extra-round-trip assertion. Verified live against a detached remote x32dbg — all three lying cases now refuse, arithmetic still works.